### PR TITLE
Add support for vulnerability tags

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,6 @@
     "src/i18n/locales"
   ],
   "i18n-ally.sourceLanguage": "en",
-  "i18n-ally.keystyle": "nested"
+  "i18n-ally.keystyle": "nested",
+  "sarif-viewer.connectToGithubCodeScanning": "off"
 }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -844,6 +844,7 @@
     "vulnerability_details": "Details zur Sicherheitsanfälligkeit",
     "vulnerability_policies": "Schwachstellen-Richtlinien",
     "vulnerability_published_desc": "Das Datum, an dem der Schwachstellendatensatz ursprünglich veröffentlicht wurde",
+    "vulnerability_tags_updated": "Schwachstellen-Tags aktualisiert",
     "vulnerability_title": "Titel",
     "vulnerability_title_desc": "Der optionale Titel der Sicherheitslücke",
     "vulnerability_updated": "Sicherheitslücke aktualisiert",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -844,6 +844,7 @@
     "vulnerability_details": "Vulnerability Details",
     "vulnerability_policies": "Vulnerability Policies",
     "vulnerability_published_desc": "The date the vulnerability record was originally published",
+    "vulnerability_tags_updated": "Vulnerability tags updated",
     "vulnerability_title": "Title",
     "vulnerability_title_desc": "The optional title of the vulnerability",
     "vulnerability_updated": "Vulnerability updated",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -844,6 +844,7 @@
     "vulnerability_details": "Detalles de vulnerabilidad",
     "vulnerability_policies": "Políticas de vulnerabilidad",
     "vulnerability_published_desc": "La fecha en que se publicó originalmente el registro de vulnerabilidad",
+    "vulnerability_tags_updated": "Etiquetas de vulnerabilidad actualizadas",
     "vulnerability_title": "Título",
     "vulnerability_title_desc": "El título opcional de la vulnerabilidad.",
     "vulnerability_updated": "Vulnerabilidad actualizada",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -844,6 +844,7 @@
     "vulnerability_details": "Détails de la vulnérabilité",
     "vulnerability_policies": "Politiques de vulnérabilité",
     "vulnerability_published_desc": "La date à laquelle l'enregistrement de vulnérabilité a été initialement publié",
+    "vulnerability_tags_updated": "Balises de vulnérabilité mises à jour",
     "vulnerability_title": "Titre",
     "vulnerability_title_desc": "Le titre de la vulnérabilité, facultatif",
     "vulnerability_updated": "Mise à jour de la vulnérabilité",

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -844,6 +844,7 @@
     "vulnerability_details": "भेद्यता विवरण",
     "vulnerability_policies": "भेद्यता नीतियाँ",
     "vulnerability_published_desc": "वह तिथि जब भेद्यता रिकॉर्ड मूल रूप से प्रकाशित किया गया था",
+    "vulnerability_tags_updated": "भेद्यता टैग अपडेट किए गए",
     "vulnerability_title": "शीर्षक",
     "vulnerability_title_desc": "भेद्यता का वैकल्पिक शीर्षक",
     "vulnerability_updated": "भेद्यता अपडेट की गई",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -844,6 +844,7 @@
     "vulnerability_details": "Dettagli sulla vulnerabilità",
     "vulnerability_policies": "Politiche di vulnerabilità",
     "vulnerability_published_desc": "La data in cui il record di vulnerabilità è stato originariamente pubblicato",
+    "vulnerability_tags_updated": "Tag di vulnerabilità aggiornati",
     "vulnerability_title": "Titolo",
     "vulnerability_title_desc": "Il titolo facoltativo della vulnerabilità",
     "vulnerability_updated": "Vulnerabilità aggiornata",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -844,6 +844,7 @@
     "vulnerability_details": "脆弱性の詳細",
     "vulnerability_policies": "脆弱性ポリシー",
     "vulnerability_published_desc": "脆弱性記録が最初に公開された日付",
+    "vulnerability_tags_updated": "脆弱性タグが更新されました",
     "vulnerability_title": "タイトル",
     "vulnerability_title_desc": "脆弱性のオプションタイトル",
     "vulnerability_updated": "脆弱性が更新されました",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -844,6 +844,7 @@
     "vulnerability_details": "Szczegóły luki",
     "vulnerability_policies": "Zasady dotyczące luk w zabezpieczeniach",
     "vulnerability_published_desc": "Data pierwotnej publikacji rejestru luk w zabezpieczeniach",
+    "vulnerability_tags_updated": "Tagi luk w zabezpieczeniach zostały zaktualizowane",
     "vulnerability_title": "Tytuł",
     "vulnerability_title_desc": "Opcjonalny tytuł luki",
     "vulnerability_updated": "Zaktualizowano lukę",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -844,6 +844,7 @@
     "vulnerability_details": "Detalhes da vulnerabilidade",
     "vulnerability_policies": "Políticas de Vulnerabilidade",
     "vulnerability_published_desc": "A data em que o registro de vulnerabilidade foi publicado originalmente",
+    "vulnerability_tags_updated": "Tags de vulnerabilidade atualizadas",
     "vulnerability_title": "Título",
     "vulnerability_title_desc": "O título opcional da vulnerabilidade",
     "vulnerability_updated": "Vulnerabilidade atualizada",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -844,6 +844,7 @@
     "vulnerability_details": "Detalhes da vulnerabilidade",
     "vulnerability_policies": "Políticas de Vulnerabilidade",
     "vulnerability_published_desc": "A data em que o registro de vulnerabilidade foi publicado originalmente",
+    "vulnerability_tags_updated": "Tags de vulnerabilidade atualizadas",
     "vulnerability_title": "Título",
     "vulnerability_title_desc": "O título opcional da vulnerabilidade",
     "vulnerability_updated": "Vulnerabilidade atualizada",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -844,6 +844,7 @@
     "vulnerability_details": "Подробности об уязвимости",
     "vulnerability_policies": "Политика уязвимостей",
     "vulnerability_published_desc": "Дата первоначальной публикации записи об уязвимости.",
+    "vulnerability_tags_updated": "Теги уязвимостей обновлены.",
     "vulnerability_title": "Заголовок",
     "vulnerability_title_desc": "Необязательное название уязвимости",
     "vulnerability_updated": "Уязвимость обновлена",

--- a/src/i18n/locales/uk-UA.json
+++ b/src/i18n/locales/uk-UA.json
@@ -844,6 +844,7 @@
     "vulnerability_details": "Деталі вразливості",
     "vulnerability_policies": "Політика вразливості",
     "vulnerability_published_desc": "Дата первинної публікації запису про вразливість",
+    "vulnerability_tags_updated": "Оновлено теги вразливості",
     "vulnerability_title": "Назва",
     "vulnerability_title_desc": "Необов’язкова назва вразливості",
     "vulnerability_updated": "Уразливість оновлено",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -844,6 +844,7 @@
     "vulnerability_details": "漏洞详细信息",
     "vulnerability_policies": "漏洞策略",
     "vulnerability_published_desc": "漏洞记录最初发布的日期",
+    "vulnerability_tags_updated": "漏洞标签已更新",
     "vulnerability_title": "标题",
     "vulnerability_title_desc": "漏洞的可选标题",
     "vulnerability_updated": "漏洞更新",

--- a/src/shared/common.js
+++ b/src/shared/common.js
@@ -49,6 +49,19 @@ $common.formatProjectTagLabel = function formatProjectTagLabel(router, tag) {
 };
 
 /**
+ * Formats and returns a specialized label for a vulnerability tag.
+ */
+$common.formatVulnerabilityTagLabel = function formatVulnerabilityTagLabel(
+  router,
+  tag,
+) {
+  if (!tag) {
+    return '';
+  }
+  return `<a href="${router.resolve({ name: 'Vulnerabilities', query: { tag: tag.name } }).href}" class="badge badge-tag text-lowercase mr-1">${xssFilters.inHTMLData(tag.name)}</a>`;
+};
+
+/**
  * Changes the first letter to uppercase and the remaining letters to lowercase.
  *
  * @param {string} string the String to capitalize
@@ -590,6 +603,7 @@ export default {
   formatSourceLabel: $common.formatSourceLabel,
   formatNotificationLabel: $common.formatNotificationLabel,
   formatProjectTagLabel: $common.formatProjectTagLabel,
+  formatVulnerabilityTagLabel: $common.formatVulnerabilityTagLabel,
   capitalize: $common.capitalize,
   formatSeverityLabel: $common.formatSeverityLabel,
   formatViolationStateLabel: $common.formatViolationStateLabel,

--- a/src/views/portfolio/vulnerabilities/Vulnerability.vue
+++ b/src/views/portfolio/vulnerabilities/Vulnerability.vue
@@ -12,6 +12,18 @@
             <div class="text-muted font-weight-bold font-xs">
               {{ vulnerability.title }}
             </div>
+            <div class="text-muted font-xs">
+              <span class="text-lowercase font-weight-bold">
+                <span v-for="tag in vulnerability.tags">
+                  <b-badge
+                    style="margin-right: 0.4rem"
+                    :to="{ name: 'Vulnerabilities', query: { tag: tag.name } }"
+                    variant="tag"
+                    >{{ tag.name }}</b-badge
+                  >
+                </span>
+              </span>
+            </div>
           </b-col>
           <b-col cols="4" class="align-middle" style="align-self: center">
             <b-row class="float-right align-middle">

--- a/src/views/portfolio/vulnerabilities/VulnerabilityDetailsModal.vue
+++ b/src/views/portfolio/vulnerabilities/VulnerabilityDetailsModal.vue
@@ -112,6 +112,35 @@
               />
             </div>
           </b-form-group>
+          <b-form-group :label="this.$t('message.tags')">
+            <b-input-group>
+              <vue-tags-input
+                id="input-4"
+                v-model="tag"
+                :tags="tags"
+                :add-on-key="addOnKeys"
+                :placeholder="$t('message.add_tag')"
+                @tags-changed="(newTags) => (this.tags = newTags)"
+                class="mw-100 bg-transparent text-lowercase"
+                style="min-width: 90%"
+                :readonly="
+                  this.isNotPermitted(PERMISSIONS.VULNERABILITY_MANAGEMENT)
+                "
+              />
+              <b-input-group-append v-show="isReadonly">
+                <b-form-group>
+                  <b-button
+                    size="md"
+                    variant="primary"
+                    @click="updateVulnerabilityTags()"
+                    v-permission="PERMISSIONS.VULNERABILITY_MANAGEMENT"
+                  >
+                    {{ $t('message.update') }}
+                  </b-button>
+                </b-form-group>
+              </b-input-group-append>
+            </b-input-group>
+          </b-form-group>
           <b-input-group-form-input
             id="vulnerability-uuid"
             input-group-size="mb-3"
@@ -1009,6 +1038,9 @@ export default {
         source: 'INTERNAL',
         affectedComponents: [],
       },
+      tag: '', // The contents of a tag as its being typed into the vue-tag-input
+      tags: [], // An array of tags bound to the vue-tag-input
+      addOnKeys: [9, 13, 32, ':', ';', ','], // Separators used when typing tags into the vue-tag-input
       severities: [
         {
           value: null,
@@ -1659,6 +1691,11 @@ export default {
     },
   },
   methods: {
+    initializeTags: function () {
+      this.tags = (this.vulnerability.tags || []).map((tag) => ({
+        text: tag.name,
+      }));
+    },
     resolveVulnAliases: function (aliases) {
       return common.resolveVulnAliases(this.vulnerability.source, aliases);
     },
@@ -1667,9 +1704,13 @@ export default {
       this.parseCvssV3Vector();
       this.parseOwaspRRVector();
       this.getAttributions();
+      this.initializeTags();
     },
     updateVulnerability: function () {
       let url = `${this.$api.BASE_URL}/${this.$api.URL_VULNERABILITY}`;
+      let tags = this.tags.map((tag) => {
+        name: tag.text;
+      });
       this.axios
         .post(url, {
           uuid: this.vulnerability.uuid,
@@ -1688,11 +1729,28 @@ export default {
           cvssV3Vector: this.generateCvssV3Vector(),
           owaspRRVector: this.generateOwaspRRVector(),
           cwes: this.selectableCwes,
+          tags: tags,
           affectedComponents: this.vulnerability.affectedComponents,
         })
         .then((response) => {
           this.$emit('vulnerabilityUpdated', response.data);
           this.$toastr.s(this.$t('message.vulnerability_updated'));
+        })
+        .catch((error) => {
+          this.$toastr.w(this.$t('condition.unsuccessful_action'));
+        })
+        .finally(() => {
+          this.$root.$emit('bv::hide::modal', 'vulnerabilityDetailsModal');
+        });
+    },
+    updateVulnerabilityTags: function () {
+      let url = `${this.$api.BASE_URL}/${this.$api.URL_VULNERABILITY}/${this.vulnerability.uuid}/tags`;
+      let tags = this.tags.map((tag) => tag.text);
+      this.axios
+        .post(url, tags)
+        .then((response) => {
+          this.$emit('vulnerabilityTagsUpdated', response.data);
+          this.$toastr.s(this.$t('message.vulnerability_tags_updated'));
         })
         .catch((error) => {
           this.$toastr.w(this.$t('condition.unsuccessful_action'));

--- a/src/views/portfolio/vulnerabilities/VulnerabilityList.vue
+++ b/src/views/portfolio/vulnerabilities/VulnerabilityList.vue
@@ -44,7 +44,12 @@ export default {
   },
   methods: {
     apiUrl: function () {
-      return `${this.$api.BASE_URL}/${this.$api.URL_VULNERABILITY}`;
+      let url = `${this.$api.BASE_URL}/${this.$api.URL_VULNERABILITY}`;
+      let tag = this.$route.query.tag;
+      if (tag) {
+        url += '/tag/' + encodeURIComponent(tag);
+      }
+      return url;
     },
     refreshTable: function () {
       this.$refs.table.refresh({
@@ -104,6 +109,36 @@ export default {
               }
               return label;
             }
+          },
+        },
+        {
+          title: this.$t('message.tags'),
+          field: 'tags',
+          sortable: false,
+          visible: false,
+          routerFunc: () => this.$router,
+          formatter(value, row, index) {
+            const router = this.routerFunc();
+            let tag_string = '';
+            if (row.tags) {
+              tag_string =
+                row.tags
+                  ?.slice(0, 2)
+                  .map((tag) => common.formatVulnerabilityTagLabel(router, tag))
+                  .join(' ') || '';
+              if (row.tags.length > 2) {
+                tag_string += ` <span class="d-none">`;
+                tag_string += row.tags
+                  .slice(2)
+                  ?.map((tag) =>
+                    common.formatVulnerabilityTagLabel(router, tag),
+                  )
+                  .join(' ');
+                tag_string += `</span>`;
+                tag_string += `<a href="#" title="show all tags" class="badge badge-tag" onclick="this.previousElementSibling.classList.toggle('d-none')">…</a>`;
+              }
+            }
+            return tag_string;
           },
         },
         {


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Adds support for vulnerability tags.

Effectively ports https://github.com/DependencyTrack/hyades-frontend/pull/45

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/hyades/blob/main/CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
