### PR TITLE
Add column for vulnerability policy operation mode

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -701,6 +701,7 @@
     "policy_last_bundle_sync_failed": "Die letzte Paket-Synchronisierung ist fehlgeschlagen",
     "policy_management": "Richtlinienverwaltung",
     "policy_name": "Versicherungsname",
+    "policy_operation_mode": "Betriebsmodus",
     "policy_violations": "Richtlinienverstöße",
     "policy_violations_by_classification": "Richtlinienverletzungen nach Klassifizierung",
     "policy_violations_by_state": "Richtlinienverstöße nach Status",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -701,6 +701,7 @@
     "policy_last_bundle_sync_failed": "Last bundle sync failed",
     "policy_management": "Policy Management",
     "policy_name": "Policy Name",
+    "policy_operation_mode": "Operation Mode",
     "policy_violations": "Policy Violations",
     "policy_violations_by_classification": "Policy Violations by Classification",
     "policy_violations_by_state": "Policy Violations by State",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -701,6 +701,7 @@
     "policy_last_bundle_sync_failed": "Falló la sincronización del último paquete",
     "policy_management": "Gestión de políticas",
     "policy_name": "Nombre de directiva",
+    "policy_operation_mode": "Modo de operación",
     "policy_violations": "Violaciones de políticas",
     "policy_violations_by_classification": "Violaciones de políticas por clasificación",
     "policy_violations_by_state": "Violaciones de políticas por estado",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -701,6 +701,7 @@
     "policy_last_bundle_sync_failed": "Échec de la dernière synchronisation du bundle",
     "policy_management": "Gestion des politiques",
     "policy_name": "Nom de la politique",
+    "policy_operation_mode": "Mode de fonctionnement",
     "policy_violations": "Violations de politiques",
     "policy_violations_by_classification": "Violations de politiques par classification",
     "policy_violations_by_state": "Violations de politiques par État",

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -701,6 +701,7 @@
     "policy_last_bundle_sync_failed": "अंतिम बंडल सिंक विफल रहा",
     "policy_management": "नीति प्रबंधन",
     "policy_name": "पालिसी का नाम",
+    "policy_operation_mode": "ऑपरेशन मोड",
     "policy_violations": "नीति उल्लंघन",
     "policy_violations_by_classification": "वर्गीकरण के अनुसार नीति उल्लंघन",
     "policy_violations_by_state": "राज्यवार नीति उल्लंघन",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -701,6 +701,7 @@
     "policy_last_bundle_sync_failed": "L'ultima sincronizzazione del bundle non è riuscita",
     "policy_management": "Gestione delle politiche",
     "policy_name": "Nome della politica",
+    "policy_operation_mode": "Modalità di funzionamento",
     "policy_violations": "Violazioni delle norme",
     "policy_violations_by_classification": "Violazioni delle policy per classificazione",
     "policy_violations_by_state": "Violazioni delle politiche da parte dello Stato",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -701,6 +701,7 @@
     "policy_last_bundle_sync_failed": "最後のバンドル同期が失敗しました",
     "policy_management": "ポリシー管理",
     "policy_name": "ポリシー名",
+    "policy_operation_mode": "動作モード",
     "policy_violations": "ポリシー違反",
     "policy_violations_by_classification": "分類別のポリシー違反",
     "policy_violations_by_state": "州別のポリシー違反",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -701,6 +701,7 @@
     "policy_last_bundle_sync_failed": "Ostatnia synchronizacja pakietu nie powiodła się",
     "policy_management": "Zarządzanie polityką",
     "policy_name": "Nazwa zasady",
+    "policy_operation_mode": "Tryb działania",
     "policy_violations": "Naruszenia zasad",
     "policy_violations_by_classification": "Naruszenia zasad według klasyfikacji",
     "policy_violations_by_state": "Naruszenia zasad według stanu",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -701,6 +701,7 @@
     "policy_last_bundle_sync_failed": "Falha na última sincronização do pacote",
     "policy_management": "Gerenciamento de Políticas",
     "policy_name": "Nome da política",
+    "policy_operation_mode": "Modo de operação",
     "policy_violations": "Violações de política",
     "policy_violations_by_classification": "Violações de política por classificação",
     "policy_violations_by_state": "Violações de políticas por estado",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -701,6 +701,7 @@
     "policy_last_bundle_sync_failed": "Falha na última sincronização do pacote",
     "policy_management": "Gerenciamento de Políticas",
     "policy_name": "Nome da política",
+    "policy_operation_mode": "Modo de operação",
     "policy_violations": "Violações de política",
     "policy_violations_by_classification": "Violações de política por classificação",
     "policy_violations_by_state": "Violações de políticas por estado",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -701,6 +701,7 @@
     "policy_last_bundle_sync_failed": "Последняя синхронизация пакета не удалась",
     "policy_management": "Управление политиками",
     "policy_name": "Имя политики",
+    "policy_operation_mode": "Режим работы",
     "policy_violations": "Нарушения политики",
     "policy_violations_by_classification": "Нарушения политики по классификации",
     "policy_violations_by_state": "Нарушения политики государством",

--- a/src/i18n/locales/uk-UA.json
+++ b/src/i18n/locales/uk-UA.json
@@ -701,6 +701,7 @@
     "policy_last_bundle_sync_failed": "Не вдалося синхронізувати останній пакет",
     "policy_management": "Управління політикою",
     "policy_name": "Назва політики",
+    "policy_operation_mode": "Режим роботи",
     "policy_violations": "Порушення політики",
     "policy_violations_by_classification": "Порушення політики за класифікацією",
     "policy_violations_by_state": "Порушення політики державою",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -701,6 +701,7 @@
     "policy_last_bundle_sync_failed": "上次捆绑包同步失败",
     "policy_management": "策略管理",
     "policy_name": "策略名称",
+    "policy_operation_mode": "操作模式",
     "policy_violations": "违反策略",
     "policy_violations_by_classification": "违反策略的分类",
     "policy_violations_by_state": "违反策略的情况",

--- a/src/views/policy/VulnerabilityPolicyList.vue
+++ b/src/views/policy/VulnerabilityPolicyList.vue
@@ -173,7 +173,7 @@ export default {
           title: this.$t('message.name'),
           field: 'name',
           sortable: true,
-          formatter(value, row, index) {
+          formatter(value) {
             return xssFilters.inHTMLData(common.valueWithDefault(value, ''));
           },
         },
@@ -181,7 +181,7 @@ export default {
           title: this.$t('message.author'),
           field: 'author',
           sortable: true,
-          formatter(value, row, index) {
+          formatter(value) {
             return xssFilters.inHTMLData(common.valueWithDefault(value, '-'));
           },
         },
@@ -189,7 +189,7 @@ export default {
           title: this.$t('message.validFrom'),
           field: 'validFrom',
           sortable: true,
-          formatter(value, row, index) {
+          formatter(value) {
             return typeof value !== 'undefined' && value != null
               ? common.formatTimestamp(Math.trunc(value * 1000))
               : '-';
@@ -199,7 +199,7 @@ export default {
           title: this.$t('message.validUntil'),
           field: 'validUntil',
           sortable: true,
-          formatter(value, row, index) {
+          formatter(value) {
             return typeof value !== 'undefined' && value != null
               ? common.formatTimestamp(Math.trunc(value * 1000))
               : '-';
@@ -209,7 +209,7 @@ export default {
           title: this.$t('message.created'),
           field: 'created',
           sortable: true,
-          formatter(value, row, index) {
+          formatter(value) {
             return typeof value !== 'undefined' && value != null
               ? common.formatTimestamp(Math.trunc(value * 1000))
               : '-';
@@ -219,10 +219,18 @@ export default {
           title: this.$t('message.updated'),
           field: 'updated',
           sortable: true,
-          formatter(value, row, index) {
+          formatter(value) {
             return typeof value !== 'undefined' && value != null
               ? common.formatTimestamp(Math.trunc(value * 1000))
               : '-';
+          },
+        },
+        {
+          title: this.$t('message.policy_operation_mode'),
+          field: 'operationMode',
+          sortable: true,
+          formatter(value) {
+            return xssFilters.inHTMLData(common.valueWithDefault(value, '-'));
           },
         },
       ],


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Adds column for vulnerability policy operation mode.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to https://github.com/DependencyTrack/hyades/issues/957
Supersedes #51

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/hyades/blob/main/CONTRIBUTING.md#pull-requests)
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://dependencytrack.github.io/hyades/latest/development/documentation/) accordingly~
