### PR TITLE
Fix CEL errors not being visualized when creating a new policy condition

### DIFF
--- a/src/views/policy/PolicyCondition.vue
+++ b/src/views/policy/PolicyCondition.vue
@@ -522,7 +522,27 @@ export default {
             this.$toastr.s(this.$t('message.updated'));
           })
           .catch((error) => {
-            this.$toastr.w(this.$t('condition.unsuccessful_action'));
+            if (
+              this.subject === 'EXPRESSION' &&
+              error.response &&
+              error.response.data &&
+              error.response.data.celErrors
+            ) {
+              this.editorMarkers = error.response.data.celErrors.map(
+                (celErr) => {
+                  return {
+                    startLineNumber: celErr.line,
+                    startColumn: celErr.column,
+                    endLineNumber: celErr.line,
+                    endColumn: celErr.column + 3, // Add a few columns to make it more visible
+                    message: celErr.message,
+                    severity: 8,
+                  };
+                },
+              );
+            } else {
+              this.$toastr.w(this.$t('condition.unsuccessful_action'));
+            }
           });
       }
     },
@@ -540,7 +560,7 @@ export default {
             this.$toastr.s(this.$t('message.condition_deleted'));
             this.$emit('conditionRemoved');
           })
-          .catch((error) => {
+          .catch(() => {
             this.$toastr.w(this.$t('condition.unsuccessful_action'));
           });
       } else {


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes CEL errors not being visualized when creating a new policy condition.

Error markers were only displayed in the expression editor when *updating* an existing condition, but not when creating a new one.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/hyades/blob/main/CONTRIBUTING.md#pull-requests)
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://dependencytrack.github.io/hyades/latest/development/documentation/) accordingly~
