### PR TITLE
Re-Calculate Historical Risk Scores

### DIFF
--- a/src/views/administration/accessmanagement/PortfolioAccessControl.vue
+++ b/src/views/administration/accessmanagement/PortfolioAccessControl.vue
@@ -241,6 +241,17 @@ export default {
           this.$toastr.w(this.$t('condition.unsuccessful_action'));
         });
     },
+    updateHistoricalRiskScore: function () {
+      let url = `${this.$api.BASE_URL}/riskscore/refresh`;
+      this.axios
+        .get(url)
+        .then((response) => {
+          this.$toastr.s(this.$t('admin.configuration_saved'));
+        })
+        .catch((error) => {
+          this.$toastr.w(this.$t('condition.unsuccessful_action'));
+        });
+    },
   },
   watch: {
     isAclEnabled() {

--- a/src/views/administration/configuration/RiskScore.vue
+++ b/src/views/administration/configuration/RiskScore.vue
@@ -184,6 +184,7 @@ export default {
           propertyValue: this.customRiskScore.unassigned,
         },
       ]);
+      this.updateHistoricalRiskScore();
     },
   },
 };


### PR DESCRIPTION
### Description

Related to https://github.com/DependencyTrack/dependency-track/issues/2824, now that risk scores can be customized, this issue should allow risk scores to be re-calculated on historical metrics as well. 

### Addressed Issue
https://github.com/DependencyTrack/dependency-track/issues/2824

### Additional Details
Goes along with a apiserver PR that adds a new endpoint to recalculate the risk scores. 

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/hyades/blob/main/CONTRIBUTING.md#pull-requests)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://dependencytrack.github.io/hyades/latest/development/documentation/) accordingly
