### PR TITLE
Fix outdated warning when `latestVersion` is empty string

### DIFF
--- a/src/views/globalAudit/VulnerabilityAuditByOccurrence.vue
+++ b/src/views/globalAudit/VulnerabilityAuditByOccurrence.vue
@@ -621,12 +621,7 @@ export default {
           field: 'component.version',
           sortable: true,
           formatter(value, row, index) {
-            if (
-              Object.prototype.hasOwnProperty.call(
-                row.component,
-                'latestVersion',
-              )
-            ) {
+            if (row.component.latestVersion) {
               if (row.component.latestVersion !== row.component.version) {
                 return (
                   '<span style="float:right" data-toggle="tooltip" data-placement="bottom" title="Risk: Outdated component. Current version is: ' +

--- a/src/views/portfolio/projects/ProjectComponents.vue
+++ b/src/views/portfolio/projects/ProjectComponents.vue
@@ -172,13 +172,7 @@ export default {
           field: 'version',
           sortable: true,
           formatter: (value, row, index) => {
-            if (
-              Object.prototype.hasOwnProperty.call(row, 'repositoryMeta') &&
-              Object.prototype.hasOwnProperty.call(
-                row.repositoryMeta,
-                'latestVersion',
-              )
-            ) {
+            if (row.repositoryMeta && row.repositoryMeta.latestVersion) {
               row.latestVersion = row.repositoryMeta.latestVersion;
               if (
                 compareVersions(row.repositoryMeta.latestVersion, row.version) >

--- a/src/views/portfolio/projects/ProjectEpss.vue
+++ b/src/views/portfolio/projects/ProjectEpss.vue
@@ -99,12 +99,7 @@ export default {
           field: 'component.version',
           sortable: true,
           formatter(value, row, index) {
-            if (
-              Object.prototype.hasOwnProperty.call(
-                row.component,
-                'latestVersion',
-              )
-            ) {
+            if (row.component.latestVersion) {
               if (
                 compareVersions(
                   row.component.latestVersion,

--- a/src/views/portfolio/projects/ProjectFindings.vue
+++ b/src/views/portfolio/projects/ProjectFindings.vue
@@ -179,12 +179,7 @@ export default {
           field: 'component.version',
           sortable: true,
           formatter(value, row, index) {
-            if (
-              Object.prototype.hasOwnProperty.call(
-                row.component,
-                'latestVersion',
-              )
-            ) {
+            if (row.component.latestVersion) {
               if (
                 compareVersions(
                   row.component.latestVersion,


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes outdated warning when `latestVersion` is empty string.

The `latestVersion` property of `repositoryMeta` objects used to be either not present (`null`, `undefined`) or hold an actual value.

For components for which no latest version was found, the `latestVersion` field occasionally holds an empty string. The `compareVersion` function used to compare versions did not take this case into consideration, causing components to be erroneously labeled as outdated.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/hyades/blob/main/CONTRIBUTING.md#pull-requests)
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://dependencytrack.github.io/hyades/latest/development/documentation/) accordingly~
