### PR TITLE
Port: Add EPSS score policy condition

### DIFF
--- a/src/views/policy/PolicyCondition.vue
+++ b/src/views/policy/PolicyCondition.vue
@@ -231,6 +231,7 @@ export default {
         { value: 'VERSION', text: this.$t('message.version') },
         { value: 'COMPONENT_HASH', text: this.$t('message.component_hash') },
         { value: 'CWE', text: this.$t('message.cwe_full') },
+        { value: 'EPSS', text: this.$t('message.epss_score') },
         {
           value: 'VULNERABILITY_ID',
           text: this.$t('message.vulnerability_vuln_id'),
@@ -318,6 +319,8 @@ export default {
           return false;
         case 'VERSION_DISTANCE':
           return false;
+        case 'EPSS':
+          return false;
         case 'EXPRESSION':
           return false;
         default:
@@ -389,6 +392,9 @@ export default {
           this.operators = this.objectOperators;
           break;
         case 'VERSION_DISTANCE':
+          this.operators = this.numericOperators;
+          break;
+        case 'EPSS':
           this.operators = this.numericOperators;
           break;
         case 'EXPRESSION':


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Ports https://github.com/DependencyTrack/frontend/pull/930 from Dependency-Track v4.12.0-SNAPSHOT.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to https://github.com/DependencyTrack/hyades/issues/1358

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

API server PR: https://github.com/DependencyTrack/hyades-apiserver/pull/834

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/hyades/blob/main/CONTRIBUTING.md#pull-requests)
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://dependencytrack.github.io/hyades/latest/development/documentation/) accordingly~
