### PR TITLE
Port : Add `BOM_VALIDATION_FAILED` To Notification Group

### DIFF
--- a/src/views/administration/notifications/Alerts.vue
+++ b/src/views/administration/notifications/Alerts.vue
@@ -188,6 +188,7 @@ export default {
                           <div class="list-group-item"><b-form-checkbox value="BOM_CONSUMED">BOM_CONSUMED</b-form-checkbox></div>
                           <div class="list-group-item"><b-form-checkbox value="BOM_PROCESSED">BOM_PROCESSED</b-form-checkbox></div>
                           <div class="list-group-item"><b-form-checkbox value="BOM_PROCESSING_FAILED">BOM_PROCESSING_FAILED</b-form-checkbox></div>
+                          <div class="list-group-item"><b-form-checkbox value="BOM_VALIDATION_FAILED">BOM_VALIDATION_FAILED</b-form-checkbox></div>
                           <div class="list-group-item"><b-form-checkbox value="VEX_CONSUMED">VEX_CONSUMED</b-form-checkbox></div>
                           <div class="list-group-item"><b-form-checkbox value="VEX_PROCESSED">VEX_PROCESSED</b-form-checkbox></div>
                           <div class="list-group-item"><b-form-checkbox value="POLICY_VIOLATION">POLICY_VIOLATION</b-form-checkbox></div>


### PR DESCRIPTION
### Description

Since `BOM_VALIDATION_FAILED` has been added as a notification, users need to be able to select it from the UI for each notification channel.

### Addressed Issue

Backport change : https://github.com/DependencyTrack/hyades/issues/1358
Backend PR : https://github.com/DependencyTrack/hyades-apiserver/pull/839

### Additional Details

<img width="1512" alt="Screenshot 2024-08-08 at 16 03 03" src="https://github.com/user-attachments/assets/8d27c730-50ed-4fa0-af56-a8421292d4cb">

### Checklist

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/hyades/blob/main/CONTRIBUTING.md#pull-requests)
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://dependencytrack.github.io/hyades/latest/development/documentation/) accordingly
