### PR TITLE
Fix "affected projects" table not showing all items

### DIFF
--- a/src/views/portfolio/vulnerabilities/AffectedProjects.vue
+++ b/src/views/portfolio/vulnerabilities/AffectedProjects.vue
@@ -113,6 +113,10 @@ export default {
           refresh: 'fa-refresh',
         },
         url: this.apiUrl(),
+        responseHandler: function (res, xhr) {
+          res.total = xhr.getResponseHeader('X-Total-Count');
+          return res;
+        },
       },
     };
   },
@@ -126,8 +130,12 @@ export default {
       }
       return url;
     },
-    tableLoaded: function (array) {
-      this.$emit('total', array.length);
+    tableLoaded: function (data) {
+      if (data && data.total !== undefined) {
+        this.$emit('total', data.total);
+      } else {
+        this.$emit('total', '?');
+      }
     },
     refreshTable: function () {
       this.$refs.table.refresh({


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes the "affected projects" table not showing all items.

The backing API endpoint is paginated now, so the table needs to evaluate the response's `X-Total-Count` header to determine how many items exist.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->


Regression of https://github.com/DependencyTrack/hyades-frontend/pull/126

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

![Screenshot 2024-09-05 at 21 55 57](https://github.com/user-attachments/assets/197df533-caf8-4575-b54c-f9940f6b6d99)

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/hyades/blob/main/CONTRIBUTING.md#pull-requests)
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://dependencytrack.github.io/hyades/latest/development/documentation/) accordingly~
