### PR TITLE
Fix : Update deprecated endpoint usage

### DIFF
--- a/src/views/portfolio/tags/SelectTagModal.vue
+++ b/src/views/portfolio/tags/SelectTagModal.vue
@@ -40,7 +40,7 @@ export default {
   mixins: [permissionsMixin],
   methods: {
     apiUrl: function () {
-      let url = `${this.$api.BASE_URL}/${this.$api.URL_TAG}/${this.policy.uuid}`;
+      let url = `${this.$api.BASE_URL}/${this.$api.URL_TAG}/policy/${this.policy.uuid}`;
       return url;
     },
     refreshTable: function () {


### PR DESCRIPTION
### Description

Remove usage of deprecated endpoints.
Found one such usage of `/api/v1/tag/{policyUuid}`, updated to `/api/v1/tag/policy/{policyUuid}`

### Addressed Issue

https://github.com/DependencyTrack/hyades/issues/1428

### Checklist

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/hyades/blob/main/CONTRIBUTING.md#pull-requests)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://dependencytrack.github.io/hyades/latest/development/documentation/) accordingly
