### PR TITLE
Port : Feat/customizable login page

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -192,6 +192,7 @@
     "permissions": "Berechtigungen",
     "personal_access_token": "Persönlicher Zugriffstoken",
     "portfolio_access_control": "Portfolio-Zugriffskontrolle",
+    "preview": "Vorschau",
     "project_access": "Projektzugriff",
     "publisher": "Publisher",
     "publisher_class": "Publisher-Klasse",
@@ -291,6 +292,9 @@
     "vulnsource_osv_advisories_enable": "Wählen Sie ein Ökosystem aus, um Google OSV Advisory Mirroring zu aktivieren",
     "vulnsource_osv_alias_sync_warning": "OSV kann nicht identische Schwachstellen als Aliase melden. Gehen Sie mit Vorsicht vor.",
     "vulnsource_osv_base_url": "OSV-Basis-URL",
+    "welcome_message": "Willkommensnachricht",
+    "welcome_message_desc": "Passen Sie die Willkommensnachricht an, die auf der Startseite von Dependency-Track angezeigt wird, bevor sich Benutzer anmelden.",
+    "welcome_message_enable": "Willkommensnachricht aktivieren",
     "workflow_step_timeout": "Schritt-Timeout",
     "workflows": "Workflows"
   },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -192,6 +192,7 @@
     "permissions": "Permissions",
     "personal_access_token": "Personal Access Token",
     "portfolio_access_control": "Portfolio Access Control",
+    "preview": "Preview",
     "project_access": "Project access",
     "publisher": "Publisher",
     "publisher_class": "Publisher class",
@@ -291,6 +292,9 @@
     "vulnsource_osv_advisories_enable": "Select ecosystem to enable Google OSV Advisory mirroring",
     "vulnsource_osv_alias_sync_warning": "OSV may report non-identical vulnerabilities as aliases. Proceed with caution.",
     "vulnsource_osv_base_url": "OSV Base URL",
+    "welcome_message": "Welcome Message",
+    "welcome_message_desc": "Customize the welcome message that appears on the start page of Dependency-Track before users sign in.",
+    "welcome_message_enable": "Enable welcome message",
     "workflow_step_timeout": "Step Timeout",
     "workflows": "Workflows"
   },

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -192,6 +192,7 @@
     "permissions": "Permisos",
     "personal_access_token": "Token de acceso personal",
     "portfolio_access_control": "Control de acceso al portafolio",
+    "preview": "Avance",
     "project_access": "Acceso al proyecto",
     "publisher": "Editor",
     "publisher_class": "Clase de editor",
@@ -291,6 +292,9 @@
     "vulnsource_osv_advisories_enable": "Seleccione el ecosistema para habilitar la duplicación del aviso OSV de Google",
     "vulnsource_osv_alias_sync_warning": "OSV puede informar vulnerabilidades no idénticas como alias. Proceda con precaución.",
     "vulnsource_osv_base_url": "URL base de OSV",
+    "welcome_message": "Mensaje de bienvenida",
+    "welcome_message_desc": "Personalice el mensaje de bienvenida que aparece en la página de inicio de Dependency-Track antes de que los usuarios inicien sesión.",
+    "welcome_message_enable": "Habilitar mensaje de bienvenida",
     "workflow_step_timeout": "Tiempo de espera del paso",
     "workflows": "Flujos de trabajo"
   },

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -192,6 +192,7 @@
     "permissions": "Autorisations",
     "personal_access_token": "Jeton d'accès personnel",
     "portfolio_access_control": "Contrôle d'accès au portefolio",
+    "preview": "Aperçu",
     "project_access": "Accès au projet",
     "publisher": "Éditeur",
     "publisher_class": "Classe d'éditeur",
@@ -291,6 +292,9 @@
     "vulnsource_osv_advisories_enable": "Sélectionnez (au moins) un écosystème pour activer la réplication de Google OSV Advisory",
     "vulnsource_osv_alias_sync_warning": "OSV peut signaler des vulnérabilités non identiques sous forme d'alias. Procéder avec prudence.",
     "vulnsource_osv_base_url": "URL de base OSV",
+    "welcome_message": "Message de bienvenue",
+    "welcome_message_desc": "Personnalisez le message de bienvenue qui apparaît sur la page de démarrage de Dependency-Track avant que les utilisateurs ne se connectent.",
+    "welcome_message_enable": "Activer le message de bienvenue",
     "workflow_step_timeout": "Délai d'expiration de l'étape",
     "workflows": "Flux de travail"
   },

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -192,6 +192,7 @@
     "permissions": "अनुमतियां",
     "personal_access_token": "व्यक्तिगत एक्सेस टोकन",
     "portfolio_access_control": "पोर्टफोलियो एक्सेस नियंत्रण",
+    "preview": "पूर्व दर्शन",
     "project_access": "परियोजना तक पहुंच",
     "publisher": "प्रकाशक",
     "publisher_class": "प्रकाशक वर्ग",
@@ -291,6 +292,9 @@
     "vulnsource_osv_advisories_enable": "Google OSV एडवाइजरी मिररिंग सक्षम करने के लिए पारिस्थितिकी तंत्र का चयन करें",
     "vulnsource_osv_alias_sync_warning": "OSV गैर-समान कमज़ोरियों को उपनाम के रूप में रिपोर्ट कर सकता है। सावधानी से आगे बढ़ें।",
     "vulnsource_osv_base_url": "OSV बेस यूआरएल",
+    "welcome_message": "स्वागत संदेश",
+    "welcome_message_desc": "उपयोगकर्ताओं के साइन इन करने से पहले डिपेंडेंसी-ट्रैक के आरंभ पृष्ठ पर दिखाई देने वाले स्वागत संदेश को अनुकूलित करें।",
+    "welcome_message_enable": "स्वागत संदेश सक्षम करें",
     "workflow_step_timeout": "चरण समयबाह्य",
     "workflows": "वर्कफ़्लो"
   },

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -192,6 +192,7 @@
     "permissions": "Autorizzazioni",
     "personal_access_token": "Token di accesso personale",
     "portfolio_access_control": "Controllo degli accessi al portafoglio",
+    "preview": "Anteprima",
     "project_access": "Accesso al progetto",
     "publisher": "Editore",
     "publisher_class": "Classe editore",
@@ -291,6 +292,9 @@
     "vulnsource_osv_advisories_enable": "Seleziona l'ecosistema per abilitare il mirroring dell'advisory OSV di Google",
     "vulnsource_osv_alias_sync_warning": "OSV può segnalare vulnerabilità non identiche come alias. Procedi con cautela.",
     "vulnsource_osv_base_url": "URL di base OSV",
+    "welcome_message": "Messaggio di benvenuto",
+    "welcome_message_desc": "Personalizza il messaggio di benvenuto che appare nella pagina iniziale di Dependency-Track prima che gli utenti accedano.",
+    "welcome_message_enable": "Abilita il messaggio di benvenuto",
     "workflow_step_timeout": "Passaggio Timeout",
     "workflows": "Flussi di lavoro"
   },

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -192,6 +192,7 @@
     "permissions": "権限",
     "personal_access_token": "パーソナルアクセストークン",
     "portfolio_access_control": "ポートフォリオアクセス制御",
+    "preview": "プレビュー",
     "project_access": "プロジェクトへのアクセス",
     "publisher": "パブリッシャー",
     "publisher_class": "パブリッシャークラス",
@@ -291,6 +292,9 @@
     "vulnsource_osv_advisories_enable": "Google OSV アドバイザリ ミラーリングを有効にするエコシステムを選択します",
     "vulnsource_osv_alias_sync_warning": "OSV は同一でない脆弱性をエイリアスとして報告する場合があります。ご注意ください。",
     "vulnsource_osv_base_url": "OSV ベース URL",
+    "welcome_message": "ウェルカムメッセージ",
+    "welcome_message_desc": "ユーザーがサインインする前に、Dependency-Track の開始ページに表示されるウェルカム メッセージをカスタマイズします。",
+    "welcome_message_enable": "ウェルカムメッセージを有効にする",
     "workflow_step_timeout": "ステップタイムアウト",
     "workflows": "ワークフロー"
   },

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -192,6 +192,7 @@
     "permissions": "Uprawnienia",
     "personal_access_token": "Osobisty token dostępu",
     "portfolio_access_control": "Kontrola dostępu do portfela",
+    "preview": "Zapowiedź",
     "project_access": "Dostęp do projektu",
     "publisher": "Wydawca",
     "publisher_class": "Klasa wydawcy",
@@ -291,6 +292,9 @@
     "vulnsource_osv_advisories_enable": "Wybierz ekosystem, aby włączyć kopię lustrzaną Doradztwa Google OSV",
     "vulnsource_osv_alias_sync_warning": "OSV może zgłaszać nieidentyczne luki w zabezpieczeniach jako aliasy. Postępuj ostrożnie.",
     "vulnsource_osv_base_url": "Podstawowy adres URL OSV",
+    "welcome_message": "Wiadomość powitalna",
+    "welcome_message_desc": "Dostosuj wiadomość powitalną wyświetlaną na stronie początkowej funkcji Depency-Track przed zalogowaniem się użytkownika.",
+    "welcome_message_enable": "Włącz wiadomość powitalną",
     "workflow_step_timeout": "Limit czasu kroku",
     "workflows": "Przepływy pracy"
   },

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -192,6 +192,7 @@
     "permissions": "Permissões",
     "personal_access_token": "Token de acesso pessoal",
     "portfolio_access_control": "Controle de acesso ao portfólio",
+    "preview": "Visualização",
     "project_access": "Acesso ao projeto",
     "publisher": "Editor",
     "publisher_class": "Classe de editor",
@@ -291,6 +292,9 @@
     "vulnsource_osv_advisories_enable": "Selecione o ecossistema para ativar o espelhamento do Google OSV Advisory",
     "vulnsource_osv_alias_sync_warning": "OSV pode relatar vulnerabilidades não idênticas como aliases. Prossiga com cuidado.",
     "vulnsource_osv_base_url": "URL base do OSV",
+    "welcome_message": "Mensagem de boas-vindas",
+    "welcome_message_desc": "Personalize a mensagem de boas-vindas que aparece na página inicial do Dependency-Track antes dos usuários fazerem login.",
+    "welcome_message_enable": "Ativar mensagem de boas-vindas",
     "workflow_step_timeout": "Tempo limite da etapa",
     "workflows": "Fluxos de trabalho"
   },

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -192,6 +192,7 @@
     "permissions": "Permissões",
     "personal_access_token": "Token de acesso pessoal",
     "portfolio_access_control": "Controle de acesso ao portfólio",
+    "preview": "Visualização",
     "project_access": "Acesso ao projeto",
     "publisher": "Editor",
     "publisher_class": "Classe de editor",
@@ -291,6 +292,9 @@
     "vulnsource_osv_advisories_enable": "Selecione o ecossistema para ativar o espelhamento do Google OSV Advisory",
     "vulnsource_osv_alias_sync_warning": "OSV pode relatar vulnerabilidades não idênticas como aliases. Prossiga com cuidado.",
     "vulnsource_osv_base_url": "URL base do OSV",
+    "welcome_message": "Mensagem de boas-vindas",
+    "welcome_message_desc": "Personalize a mensagem de boas-vindas que aparece na página inicial do Dependency-Track antes dos usuários fazerem login.",
+    "welcome_message_enable": "Ativar mensagem de boas-vindas",
     "workflow_step_timeout": "Tempo limite da etapa",
     "workflows": "Fluxos de trabalho"
   },

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -192,6 +192,7 @@
     "permissions": "Разрешения",
     "personal_access_token": "Токен личного доступа",
     "portfolio_access_control": "Контроль доступа к портфолио",
+    "preview": "Предварительный просмотр",
     "project_access": "Доступ к проекту",
     "publisher": "Издатель",
     "publisher_class": "Класс издателя",
@@ -291,6 +292,9 @@
     "vulnsource_osv_advisories_enable": "Выберите экосистему, чтобы включить зеркалирование рекомендаций Google OSV.",
     "vulnsource_osv_alias_sync_warning": "OSV может сообщать о неидентичных уязвимостях как псевдонимах. Действовать с осторожностью.",
     "vulnsource_osv_base_url": "Базовый URL-адрес OSV",
+    "welcome_message": "Приветственное сообщение",
+    "welcome_message_desc": "Настройте приветственное сообщение, которое появляется на стартовой странице Dependency-Track перед входом пользователей.",
+    "welcome_message_enable": "Включить приветственное сообщение",
     "workflow_step_timeout": "Тайм-аут шага",
     "workflows": "Рабочие процессы"
   },

--- a/src/i18n/locales/uk-UA.json
+++ b/src/i18n/locales/uk-UA.json
@@ -192,6 +192,7 @@
     "permissions": "Дозволи",
     "personal_access_token": "Персональний маркер доступу",
     "portfolio_access_control": "Контроль доступу до портфоліо",
+    "preview": "Попередній перегляд",
     "project_access": "Доступ до проекту",
     "publisher": "Видавець",
     "publisher_class": "Клас видавця",
@@ -291,6 +292,9 @@
     "vulnsource_osv_advisories_enable": "Виберіть екосистему, щоб увімкнути віддзеркалення Google OSV Advisory",
     "vulnsource_osv_alias_sync_warning": "OSV може повідомляти про неідентичні вразливості як псевдоніми. \nДійте обережно.",
     "vulnsource_osv_base_url": "Базовий URL OSV",
+    "welcome_message": "Вітальне повідомлення",
+    "welcome_message_desc": "Налаштуйте вітальне повідомлення, яке з’являється на початковій сторінці Dependency-Track перед входом користувачів.",
+    "welcome_message_enable": "Увімкнути вітальне повідомлення",
     "workflow_step_timeout": "Час очікування кроку",
     "workflows": "Робочі процеси"
   },

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -192,6 +192,7 @@
     "permissions": "权限",
     "personal_access_token": "个人访问令牌",
     "portfolio_access_control": "portfolio 访问控制",
+    "preview": "预览",
     "project_access": "项目访问",
     "publisher": "发行商",
     "publisher_class": "发行商分类",
@@ -291,6 +292,9 @@
     "vulnsource_osv_advisories_enable": "选择生态系统以启用 Google OSV 咨询镜像",
     "vulnsource_osv_alias_sync_warning": "OSV 可能会将不相同的漏洞报告为别名。请谨慎操作。",
     "vulnsource_osv_base_url": "OSV 基本 URL",
+    "welcome_message": "欢迎辞",
+    "welcome_message_desc": "自定义用户登录前 Dependency-Track 起始页上显示的欢迎消息。",
+    "welcome_message_enable": "启用欢迎消息",
     "workflow_step_timeout": "步骤超时",
     "workflows": "工作流程"
   },

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -26,6 +26,8 @@ const Administration = () => import('@/views/administration/Administration');
 const General = () => import('@/views/administration/configuration/General');
 const BomFormats = () =>
   import('@/views/administration/configuration/BomFormats');
+const WelcomeMessage = () =>
+  import('@/views/administration/configuration/WelcomeMessage');
 const Email = () => import('@/views/administration/configuration/Email');
 const Jira = () => import('@/views/administration/configuration/JiraConfig');
 const InternalComponents = () =>
@@ -378,6 +380,16 @@ function configRoutes() {
                   'SYSTEM_CONFIGURATION_UPDATE',
                   'SYSTEM_CONFIGURATION_DELETE',
                 ],
+              },
+            },
+            {
+              path: 'configuration/welcomeMessage',
+              component: WelcomeMessage,
+              meta: {
+                title: i18n.t('message.administration'),
+                i18n: 'message.administration',
+                sectionPath: '/admin',
+                permission: 'SYSTEM_CONFIGURATION',
               },
             },
             {

--- a/src/views/administration/AdminMenu.vue
+++ b/src/views/administration/AdminMenu.vue
@@ -110,6 +110,11 @@ export default {
               route: 'configuration/email',
             },
             {
+              component: 'WelcomeMessage',
+              name: this.$t('admin.welcome_message'),
+              route: 'configuration/welcomeMessage',
+            },
+            {
               component: 'InternalComponents',
               name: this.$t('admin.internal_components'),
               route: 'configuration/internalComponents',

--- a/src/views/administration/Administration.vue
+++ b/src/views/administration/Administration.vue
@@ -37,6 +37,7 @@ import Search from './configuration/Search.vue';
 import TaskScheduler from './configuration/TaskScheduler.vue';
 import RiskScore from './configuration/RiskScore.vue';
 import Experimental from './configuration/Experimental.vue';
+import WelcomeMessage from './configuration/WelcomeMessage.vue';
 // Analyzer plugins
 import InternalAnalyzer from './analyzers/InternalAnalyzer';
 import OssIndexAnalyzer from './analyzers/OssIndexAnalyzer';
@@ -82,6 +83,7 @@ export default {
     EventBus,
     AdminMenu,
     General,
+    WelcomeMessage,
     BomFormats,
     Email,
     Jira,

--- a/src/views/administration/configuration/WelcomeMessage.vue
+++ b/src/views/administration/configuration/WelcomeMessage.vue
@@ -1,0 +1,116 @@
+<template>
+    <div>
+      <b-card no-body :header="header">
+        <b-card-group>
+          <b-card-body>
+            <p>{{ $t('admin.welcome_message_desc') }}</p>
+            <b-form-group
+              :label="$t('admin.welcome_message')"
+              label-size="lg"
+              label-class="font-weight-bold pt-0 mb-2"
+            >
+              <div id="customToolbar">
+                <c-switch
+                  id="isWelcomeMessage"
+                  color="primary"
+                  v-model="isWelcomeMessage"
+                  label
+                  v-bind="labelIcon"
+                />{{ $t('admin.welcome_message_enable') }}
+              </div>
+              <textarea
+                ref="editor"
+                :disabled="!isWelcomeMessage"
+                class="form-control"
+                :value="welcomeMessage"
+                @input="updateCode"
+              />
+            </b-form-group>
+          </b-card-body>
+        </b-card-group>
+        <b-card-footer>
+          <b-button
+            :disabled="!this.welcomeMessage && this.isWelcomeMessage"
+            variant="outline-primary"
+            class="px-4"
+            @click="saveChanges"
+          >
+            {{ $t('message.update') }}
+          </b-button>
+        </b-card-footer>
+      </b-card>
+      <div class="container">
+        <b-row class="justify-content-center">
+          <b-col md="8">
+            <b-card v-if="isWelcomeMessage" class="bg-grey-900">
+              <div slot="header">
+                <h4>{{ $t('admin.preview') }}</h4>
+              </div>
+              <p><span v-html="welcomeMessage" /></p>
+            </b-card>
+          </b-col>
+        </b-row>
+      </div>
+    </div>
+  </template>
+  <script>
+  import axios from 'axios';
+  import { Switch as cSwitch } from '@coreui/vue';
+  import configPropertyMixin from '../mixins/configPropertyMixin';
+  import common from '../../../shared/common';
+  
+  export default {
+    mixins: [configPropertyMixin],
+    props: {
+      header: String,
+    },
+    components: {
+      cSwitch,
+    },
+    data() {
+      return {
+        isWelcomeMessage: false,
+        welcomeMessage: '',
+      };
+    },
+    created() {
+      let message_url = `${this.$api.BASE_URL}/${this.$api.URL_CONFIG_PROPERTY}/public/general/welcome.message.html`;
+      let enabled_url = `${this.$api.BASE_URL}/${this.$api.URL_CONFIG_PROPERTY}/public/general/welcome.message.enabled`;
+      axios.get(message_url).then((response) => {
+        this.welcomeMessage = decodeURIComponent(response.data.propertyValue);
+      });
+      axios.get(enabled_url).then((response) => {
+        this.isWelcomeMessage = common.toBoolean(response.data.propertyValue);
+      });
+    },
+    computed: {},
+    methods: {
+      updateCode() {
+        const editor = this.$refs.editor;
+        this.welcomeMessage = editor.value;
+        editor.style.height = editor.scrollHeight + 'px';
+      },
+      saveChanges() {
+        let url = `${this.$api.BASE_URL}/${this.$api.URL_CONFIG_PROPERTY}`;
+        axios.post(url, {
+          groupName: 'general',
+          propertyName: 'welcome.message.html',
+          propertyValue: encodeURIComponent(
+            this.welcomeMessage !== '' ? this.welcomeMessage : ' ',
+          ),
+        });
+        axios.post(url, {
+          groupName: 'general',
+          propertyName: 'welcome.message.enabled',
+          propertyValue: this.isWelcomeMessage,
+        })
+        .then((response) => {
+          this.$toastr.s(this.$t('admin.configuration_saved'));
+        })
+        .catch((error) => {
+          this.$toastr.w(this.$t('condition.unsuccessful_action'));
+        });
+      },
+    },
+  };
+  </script>

--- a/src/views/administration/configuration/WelcomeMessage.vue
+++ b/src/views/administration/configuration/WelcomeMessage.vue
@@ -1,105 +1,106 @@
 <template>
-    <div>
-      <b-card no-body :header="header">
-        <b-card-group>
-          <b-card-body>
-            <p>{{ $t('admin.welcome_message_desc') }}</p>
-            <b-form-group
-              :label="$t('admin.welcome_message')"
-              label-size="lg"
-              label-class="font-weight-bold pt-0 mb-2"
-            >
-              <div id="customToolbar">
-                <c-switch
-                  id="isWelcomeMessage"
-                  color="primary"
-                  v-model="isWelcomeMessage"
-                  label
-                  v-bind="labelIcon"
-                />{{ $t('admin.welcome_message_enable') }}
-              </div>
-              <textarea
-                ref="editor"
-                :disabled="!isWelcomeMessage"
-                class="form-control"
-                :value="welcomeMessage"
-                @input="updateCode"
-              />
-            </b-form-group>
-          </b-card-body>
-        </b-card-group>
-        <b-card-footer>
-          <b-button
-            :disabled="!this.welcomeMessage && this.isWelcomeMessage"
-            variant="outline-primary"
-            class="px-4"
-            @click="saveChanges"
+  <div>
+    <b-card no-body :header="header">
+      <b-card-group>
+        <b-card-body>
+          <p>{{ $t('admin.welcome_message_desc') }}</p>
+          <b-form-group
+            :label="$t('admin.welcome_message')"
+            label-size="lg"
+            label-class="font-weight-bold pt-0 mb-2"
           >
-            {{ $t('message.update') }}
-          </b-button>
-        </b-card-footer>
-      </b-card>
-      <div class="container">
-        <b-row class="justify-content-center">
-          <b-col md="8">
-            <b-card v-if="isWelcomeMessage" class="bg-grey-900">
-              <div slot="header">
-                <h4>{{ $t('admin.preview') }}</h4>
-              </div>
-              <p><span v-html="welcomeMessage" /></p>
-            </b-card>
-          </b-col>
-        </b-row>
-      </div>
+            <div id="customToolbar">
+              <c-switch
+                id="isWelcomeMessage"
+                color="primary"
+                v-model="isWelcomeMessage"
+                label
+                v-bind="labelIcon"
+              />{{ $t('admin.welcome_message_enable') }}
+            </div>
+            <textarea
+              ref="editor"
+              :disabled="!isWelcomeMessage"
+              class="form-control"
+              :value="welcomeMessage"
+              @input="updateCode"
+            />
+          </b-form-group>
+        </b-card-body>
+      </b-card-group>
+      <b-card-footer>
+        <b-button
+          :disabled="!this.welcomeMessage && this.isWelcomeMessage"
+          variant="outline-primary"
+          class="px-4"
+          @click="saveChanges"
+        >
+          {{ $t('message.update') }}
+        </b-button>
+      </b-card-footer>
+    </b-card>
+    <div class="container">
+      <b-row class="justify-content-center">
+        <b-col md="8">
+          <b-card v-if="isWelcomeMessage" class="bg-grey-900">
+            <div slot="header">
+              <h4>{{ $t('admin.preview') }}</h4>
+            </div>
+            <p><span v-html="welcomeMessage" /></p>
+          </b-card>
+        </b-col>
+      </b-row>
     </div>
-  </template>
-  <script>
-  import axios from 'axios';
-  import { Switch as cSwitch } from '@coreui/vue';
-  import configPropertyMixin from '../mixins/configPropertyMixin';
-  import common from '../../../shared/common';
-  
-  export default {
-    mixins: [configPropertyMixin],
-    props: {
-      header: String,
+  </div>
+</template>
+<script>
+import axios from 'axios';
+import { Switch as cSwitch } from '@coreui/vue';
+import configPropertyMixin from '../mixins/configPropertyMixin';
+import common from '../../../shared/common';
+
+export default {
+  mixins: [configPropertyMixin],
+  props: {
+    header: String,
+  },
+  components: {
+    cSwitch,
+  },
+  data() {
+    return {
+      isWelcomeMessage: false,
+      welcomeMessage: '',
+    };
+  },
+  created() {
+    let message_url = `${this.$api.BASE_URL}/${this.$api.URL_CONFIG_PROPERTY}/public/general/welcome.message.html`;
+    let enabled_url = `${this.$api.BASE_URL}/${this.$api.URL_CONFIG_PROPERTY}/public/general/welcome.message.enabled`;
+    axios.get(message_url).then((response) => {
+      this.welcomeMessage = decodeURIComponent(response.data.propertyValue);
+    });
+    axios.get(enabled_url).then((response) => {
+      this.isWelcomeMessage = common.toBoolean(response.data.propertyValue);
+    });
+  },
+  computed: {},
+  methods: {
+    updateCode() {
+      const editor = this.$refs.editor;
+      this.welcomeMessage = editor.value;
+      editor.style.height = editor.scrollHeight + 'px';
     },
-    components: {
-      cSwitch,
-    },
-    data() {
-      return {
-        isWelcomeMessage: false,
-        welcomeMessage: '',
-      };
-    },
-    created() {
-      let message_url = `${this.$api.BASE_URL}/${this.$api.URL_CONFIG_PROPERTY}/public/general/welcome.message.html`;
-      let enabled_url = `${this.$api.BASE_URL}/${this.$api.URL_CONFIG_PROPERTY}/public/general/welcome.message.enabled`;
-      axios.get(message_url).then((response) => {
-        this.welcomeMessage = decodeURIComponent(response.data.propertyValue);
+    saveChanges() {
+      let url = `${this.$api.BASE_URL}/${this.$api.URL_CONFIG_PROPERTY}`;
+      axios.post(url, {
+        groupName: 'general',
+        propertyName: 'welcome.message.html',
+        propertyValue: encodeURIComponent(
+          this.welcomeMessage !== '' ? this.welcomeMessage : ' ',
+        ),
       });
-      axios.get(enabled_url).then((response) => {
-        this.isWelcomeMessage = common.toBoolean(response.data.propertyValue);
-      });
-    },
-    computed: {},
-    methods: {
-      updateCode() {
-        const editor = this.$refs.editor;
-        this.welcomeMessage = editor.value;
-        editor.style.height = editor.scrollHeight + 'px';
-      },
-      saveChanges() {
-        let url = `${this.$api.BASE_URL}/${this.$api.URL_CONFIG_PROPERTY}`;
-        axios.post(url, {
-          groupName: 'general',
-          propertyName: 'welcome.message.html',
-          propertyValue: encodeURIComponent(
-            this.welcomeMessage !== '' ? this.welcomeMessage : ' ',
-          ),
-        });
-        axios.post(url, {
+      axios
+        .post(url, {
           groupName: 'general',
           propertyName: 'welcome.message.enabled',
           propertyValue: this.isWelcomeMessage,
@@ -110,7 +111,7 @@
         .catch((error) => {
           this.$toastr.w(this.$t('condition.unsuccessful_action'));
         });
-      },
     },
-  };
-  </script>
+  },
+};
+</script>

--- a/src/views/pages/Login.vue
+++ b/src/views/pages/Login.vue
@@ -3,6 +3,11 @@
     <div class="container">
       <b-row class="justify-content-center">
         <b-col md="8">
+          <b-card v-if="isWelcomeMessage" no-body class="bg-grey-900 p-4 m-0">
+            <div>
+              <p><span v-html="welcomeMessage" /></p>
+            </div>
+          </b-card>
           <b-card-group>
             <b-card no-body class="p-4">
               <b-card-body>
@@ -105,6 +110,7 @@ import InformationalModal from '../modals/InformationalModal';
 import EventBus from '../../shared/eventbus';
 import { getRedirectUrl } from '../../shared/utils';
 const qs = require('querystring');
+import common from '../../shared/common';
 
 export default {
   name: 'Login',
@@ -115,6 +121,8 @@ export default {
   },
   data() {
     return {
+      isWelcomeMessage: true,
+      welcomeMessage: '',
       loginError: '',
       input: {
         username: '',
@@ -133,6 +141,24 @@ export default {
       }),
       showLoginForm: false,
     };
+  },
+  beforeMount() {
+    let enabled_url = `${this.$api.BASE_URL}/${this.$api.URL_CONFIG_PROPERTY}/public/general/welcome.message.enabled`;
+    axios
+      .get(enabled_url)
+      .then((response) => {
+        this.isWelcomeMessage = common.toBoolean(response.data.propertyValue);
+      })
+      .then(() => {
+        if (this.isWelcomeMessage) {
+          let message_url = `${this.$api.BASE_URL}/${this.$api.URL_CONFIG_PROPERTY}/public/general/welcome.message.html`;
+          axios.get(message_url).then((response) => {
+            this.welcomeMessage = decodeURIComponent(
+              response.data.propertyValue,
+            );
+          });
+        }
+      });
   },
   methods: {
     login() {
@@ -217,6 +243,9 @@ export default {
     },
     oidcLoginButtonText() {
       return this.$oidc.LOGIN_BUTTON_TEXT;
+    },
+    goToLogin() {
+      this.isWelcomeMessage = false;
     },
   },
   mounted() {


### PR DESCRIPTION
### Description

Add a option in configuration tab, to enable and set a custom welcome message:

<img width="1258" alt="Screenshot 2024-09-18 at 14 01 54" src="https://github.com/user-attachments/assets/fec33433-1d4c-4727-8b90-0c58f5fbc0ab">

That Welcome Message is shown on the login Screen:

<img width="1415" alt="Screenshot 2024-09-18 at 14 10 48" src="https://github.com/user-attachments/assets/9f4b14a9-23e5-4090-ba09-fe46416a01d9">

### Addressed Issue

Port change https://github.com/DependencyTrack/hyades/issues/1358

### Checklist

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/hyades/blob/main/CONTRIBUTING.md#pull-requests)
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://dependencytrack.github.io/hyades/latest/development/documentation/) accordingly
