### PR TITLE
Port : Add ability to test notification publishers

### DIFF
--- a/src/views/administration/notifications/Alerts.vue
+++ b/src/views/administration/notifications/Alerts.vue
@@ -221,6 +221,7 @@ export default {
                       </div>
                     </b-form-group>
                     <div style="text-align:right">
+                      <b-button variant="outline-primary" @click="testNotification">{{ $t('admin.perform_test') }}</b-button>
                       <b-toggleable-display-button variant="outline-primary" :label="$t('admin.limit_to')"
                                 v-permission="PERMISSIONS.VIEW_PORTFOLIO" v-on:toggle="limitToVisible = !limitToVisible"
                                 v-if="this.scope === 'PORTFOLIO'" />
@@ -407,6 +408,24 @@ export default {
                     }
                     this.projects = p;
                     this.$toastr.s(this.$t('message.updated'));
+                  })
+                  .catch((error) => {
+                    this.$toastr.w(this.$t('condition.unsuccessful_action'));
+                  });
+              },
+              testNotification: function () {
+                let url = `${this.$api.BASE_URL}/${this.$api.URL_NOTIFICATION_PUBLISHER}/test/${this.uuid}`;
+                let params = new URLSearchParams();
+                params.append('destination', this.destination);
+                this.axios
+                  .post(url, params, {
+                    headers: {
+                      'Content-Type': 'application/x-www-form-urlencoded',
+                    },
+                  })
+                  .then((response) => {
+                    this.alert = response.data;
+                    this.$toastr.s(this.$t('admin.test_notification_queued'));
                   })
                   .catch((error) => {
                     this.$toastr.w(this.$t('condition.unsuccessful_action'));


### PR DESCRIPTION
### Description

Frontend for new endpoint that can be used to send out a notification test for the specified rule using its UUID https://github.com/DependencyTrack/hyades-apiserver/pull/928

### Addressed Issue

Port change https://github.com/DependencyTrack/hyades/issues/1358

### Additional Details



### Checklist

- [ ] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/hyades/blob/main/CONTRIBUTING.md#pull-requests)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://dependencytrack.github.io/hyades/latest/development/documentation/) accordingly
