### PR TITLE
Port : Global Audit View: Policy Violations

### DIFF
--- a/src/containers/DefaultContainer.vue
+++ b/src/containers/DefaultContainer.vue
@@ -116,13 +116,22 @@ export default {
             element: '',
             attributes: {},
           },
-          permission: permissions.VIEW_VULNERABILITY,
+          permissions: [
+            permissions.VIEW_VULNERABILITY,
+            permissions.VIEW_POLICY_VIOLATION,
+          ],
         },
         {
           name: this.$t('message.vulnerability_audit'),
           url: '/vulnerabilityAudit',
           icon: 'fa fa-tasks',
           permission: permissions.VIEW_VULNERABILITY,
+        },
+        {
+          name: this.$t('message.policy_violation_audit'),
+          url: '/policyViolationAudit',
+          icon: 'fa fa-fire',
+          permission: permissions.VIEW_POLICY_VIOLATION,
         },
         {
           title: true,
@@ -222,8 +231,12 @@ export default {
       let array = [];
       for (const item of this.nav) {
         if (
-          item.permission !== null &&
-          permissions.hasPermission(item.permission, decodedToken)
+          (item.permission !== null &&
+            permissions.hasPermission(item.permission, decodedToken)) ||
+          (Object.prototype.hasOwnProperty.call(item, 'permissions') &&
+            item.permissions.some((permission) =>
+              permissions.hasPermission(permission, decodedToken),
+            ))
         ) {
           array.push(item);
         }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -728,6 +728,7 @@
     "policy_management": "Richtlinienverwaltung",
     "policy_name": "Versicherungsname",
     "policy_operation_mode": "Betriebsmodus",
+    "policy_violation_audit": "Richtlinienverstoß-Audit",
     "policy_violations": "Richtlinienverstöße",
     "policy_violations_by_classification": "Richtlinienverletzungen nach Klassifizierung",
     "policy_violations_by_state": "Richtlinienverstöße nach Status",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -728,6 +728,7 @@
     "policy_management": "Policy Management",
     "policy_name": "Policy Name",
     "policy_operation_mode": "Operation Mode",
+    "policy_violation_audit": "Policy Violation Audit",
     "policy_violations": "Policy Violations",
     "policy_violations_by_classification": "Policy Violations by Classification",
     "policy_violations_by_state": "Policy Violations by State",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -728,6 +728,7 @@
     "policy_management": "Gestión de políticas",
     "policy_name": "Nombre de directiva",
     "policy_operation_mode": "Modo de operación",
+    "policy_violation_audit": "Auditoría de violaciones de políticas",
     "policy_violations": "Violaciones de políticas",
     "policy_violations_by_classification": "Violaciones de políticas por clasificación",
     "policy_violations_by_state": "Violaciones de políticas por estado",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -728,6 +728,7 @@
     "policy_management": "Gestion des politiques",
     "policy_name": "Nom de la politique",
     "policy_operation_mode": "Mode de fonctionnement",
+    "policy_violation_audit": "Audit des violations des politiques",
     "policy_violations": "Violations de politiques",
     "policy_violations_by_classification": "Violations de politiques par classification",
     "policy_violations_by_state": "Violations de politiques par État",

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -728,6 +728,7 @@
     "policy_management": "नीति प्रबंधन",
     "policy_name": "पालिसी का नाम",
     "policy_operation_mode": "ऑपरेशन मोड",
+    "policy_violation_audit": "नीति उल्लंघन ऑडिट",
     "policy_violations": "नीति उल्लंघन",
     "policy_violations_by_classification": "वर्गीकरण के अनुसार नीति उल्लंघन",
     "policy_violations_by_state": "राज्यवार नीति उल्लंघन",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -728,6 +728,7 @@
     "policy_management": "Gestione delle politiche",
     "policy_name": "Nome della politica",
     "policy_operation_mode": "Modalità di funzionamento",
+    "policy_violation_audit": "Controllo della violazione delle policy",
     "policy_violations": "Violazioni delle norme",
     "policy_violations_by_classification": "Violazioni delle policy per classificazione",
     "policy_violations_by_state": "Violazioni delle politiche da parte dello Stato",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -728,6 +728,7 @@
     "policy_management": "ポリシー管理",
     "policy_name": "ポリシー名",
     "policy_operation_mode": "動作モード",
+    "policy_violation_audit": "ポリシー違反の監査",
     "policy_violations": "ポリシー違反",
     "policy_violations_by_classification": "分類別のポリシー違反",
     "policy_violations_by_state": "州別のポリシー違反",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -728,6 +728,7 @@
     "policy_management": "Zarządzanie polityką",
     "policy_name": "Nazwa zasady",
     "policy_operation_mode": "Tryb działania",
+    "policy_violation_audit": "Audyt naruszeń zasad",
     "policy_violations": "Naruszenia zasad",
     "policy_violations_by_classification": "Naruszenia zasad według klasyfikacji",
     "policy_violations_by_state": "Naruszenia zasad według stanu",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -728,6 +728,7 @@
     "policy_management": "Gerenciamento de Políticas",
     "policy_name": "Nome da política",
     "policy_operation_mode": "Modo de operação",
+    "policy_violation_audit": "Auditoria de violação de política",
     "policy_violations": "Violações de política",
     "policy_violations_by_classification": "Violações de política por classificação",
     "policy_violations_by_state": "Violações de políticas por estado",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -728,6 +728,7 @@
     "policy_management": "Gerenciamento de Políticas",
     "policy_name": "Nome da política",
     "policy_operation_mode": "Modo de operação",
+    "policy_violation_audit": "Auditoria de violação de políticas",
     "policy_violations": "Violações de política",
     "policy_violations_by_classification": "Violações de política por classificação",
     "policy_violations_by_state": "Violações de políticas por estado",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -728,6 +728,7 @@
     "policy_management": "Управление политиками",
     "policy_name": "Имя политики",
     "policy_operation_mode": "Режим работы",
+    "policy_violation_audit": "Аудит нарушений политики",
     "policy_violations": "Нарушения политики",
     "policy_violations_by_classification": "Нарушения политики по классификации",
     "policy_violations_by_state": "Нарушения политики государством",

--- a/src/i18n/locales/uk-UA.json
+++ b/src/i18n/locales/uk-UA.json
@@ -728,6 +728,7 @@
     "policy_management": "Управління політикою",
     "policy_name": "Назва політики",
     "policy_operation_mode": "Режим роботи",
+    "policy_violation_audit": "Аудит порушень політики",
     "policy_violations": "Порушення політики",
     "policy_violations_by_classification": "Порушення політики за класифікацією",
     "policy_violations_by_state": "Порушення політики державою",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -728,6 +728,7 @@
     "policy_management": "策略管理",
     "policy_name": "策略名称",
     "policy_operation_mode": "操作模式",
+    "policy_violation_audit": "政策违规审计",
     "policy_violations": "违反策略",
     "policy_violations_by_classification": "违反策略的分类",
     "policy_violations_by_state": "违反策略的情况",

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -21,6 +21,7 @@ const VulnerabilityAudit = () =>
 const LicenseList = () => import('@/views/portfolio/licenses/LicenseList');
 const PolicyManagement = () => import('@/views/policy/PolicyManagement');
 const Project = () => import('@/views/portfolio/projects/Project');
+const PolicyViolationAudit = () => import('@/views/audit/PolicyViolationAudit');
 
 const Administration = () => import('@/views/administration/Administration');
 const General = () => import('@/views/administration/configuration/General');
@@ -330,6 +331,16 @@ function configRoutes() {
               'POLICY_MANAGEMENT_UPDATE',
               'POLICY_MANAGEMENT_DELETE',
             ],
+          },
+        },
+        {
+          path: 'policyViolationAudit',
+          component: PolicyViolationAudit,
+          meta: {
+            title: i18n.t('message.policy_violation_audit'),
+            i18n: 'message.policy_violation_audit',
+            sectionPath: '/audit',
+            permission: 'VIEW_POLICY_VIOLATION',
           },
         },
         {

--- a/src/shared/utils.js
+++ b/src/shared/utils.js
@@ -53,6 +53,7 @@ const acceptableRootContextPaths = [
   '/vulnerability',
   '/license',
   '/vulnerabilityAudit',
+  '/policyViolationAudit',
   '/login',
   '/change-password',
 ];

--- a/src/views/audit/PolicyViolationAudit.vue
+++ b/src/views/audit/PolicyViolationAudit.vue
@@ -1,0 +1,505 @@
+<template>
+    <div class="animated fadeIn" v-permission="PERMISSIONS.VIEW_POLICY_VIOLATION">
+      <b-row>
+        <b-col xs="6" sm="4" md="4" lg="2" id="filter-controls">
+          <div>
+            <h3 style="display: inline">{{ this.$t('message.filters') }}</h3>
+            <b-button
+              size="md"
+              variant="outline-primary"
+              style="float: right"
+              @click="clearAllFilters()"
+            >
+              {{ this.$t('message.clear_all') }}</b-button
+            >
+            <br /><br />
+            <b-form-group
+              id="showInactive-form-group"
+              :label="this.$t('message.projects')"
+            >
+              <b-form-checkbox
+                id="showInactive-form-checkbox"
+                v-model="showInactive"
+                value="true"
+                unchecked-value="false"
+              >
+                {{ this.$t('message.show_inactive_projects') }}
+              </b-form-checkbox>
+            </b-form-group>
+            <b-form-group
+              id="showSuppressed-form-group"
+              :label="this.$t('message.analysis_status')"
+            >
+              <b-form-checkbox
+                id="showSuppressed-form-checkbox"
+                v-model="showSuppressed"
+                value="true"
+                unchecked-value="false"
+              >
+                {{ this.$t('message.show_suppressed_violations') }}
+              </b-form-checkbox>
+            </b-form-group>
+            <b-form-group
+              id="violation-state-form-group"
+              :label="this.$t('message.violation_state')"
+            >
+              <b-form-checkbox-group
+                id="violation-state-form-checkbox-group"
+                v-model="violationStateSelected"
+                :options="violationStateOptions"
+                stacked
+              >
+              </b-form-checkbox-group>
+            </b-form-group>
+            <b-form-group
+              id="risk-type-form-group"
+              :label="this.$t('message.risk_type')"
+            >
+              <b-form-checkbox-group
+                id="risk-type-form-checkbox-group"
+                v-model="riskTypeSelected"
+                :options="riskTypeOptions"
+                stacked
+              >
+              </b-form-checkbox-group>
+            </b-form-group>
+            <b-form-group
+              id="analysis-type-form-group"
+              :label="this.$t('message.analysis_state')"
+            >
+              <b-form-checkbox-group
+                id="analysis-type-form-checkbox-group"
+                v-model="analysisStateSelected"
+                :options="analysisStateOptions"
+                stacked
+              >
+              </b-form-checkbox-group>
+            </b-form-group>
+            <b-form-group
+              id="occurred-on-date-form-group"
+              :label="this.$t('message.occurred_on')"
+            >
+              <b-datepicker
+                id="occurred-on-datepicker-from"
+                v-model="occurredOnDateFrom"
+                :max="occurredOnDateTo"
+                :placeholder="this.$t('message.from')"
+              ></b-datepicker>
+              <b-datepicker
+                id="occurred-on-datepicker-to"
+                v-model="occurredOnDateTo"
+                :min="occurredOnDateFrom"
+                :placeholder="this.$t('message.to')"
+              ></b-datepicker>
+            </b-form-group>
+            <b-form-group
+              id="text-search-form-group"
+              :label="this.$t('message.text_search')"
+            >
+              <b-form-input
+                id="text-search-form-input"
+                v-model="textSearchInput"
+                debounce="750"
+                :placeholder="this.$t('message.search')"
+              ></b-form-input>
+              Search in:
+              <b-form-checkbox-group
+                id="text-search-form-checkbox-group"
+                v-model="textSearchSelected"
+                :options="textSearchOptions"
+                stacked
+              >
+              </b-form-checkbox-group>
+            </b-form-group>
+            <b-form-group
+              id="policy-form-group"
+              :label="this.$t('message.policies')"
+              v-permission="PERMISSIONS.POLICY_MANAGEMENT"
+            >
+              <b-form-checkbox-group
+                id="policy-form-checkbox-group"
+                v-model="policySelected"
+                :options="policyOptions"
+                stacked
+              >
+              </b-form-checkbox-group>
+            </b-form-group>
+          </div>
+        </b-col>
+        <b-col xs="6" sm="8" md="8" lg="10">
+          <bootstrap-table
+            ref="table"
+            :columns="columns"
+            :data="data"
+            :options="options"
+            @on-load-success="onLoadSuccess"
+          >
+          </bootstrap-table>
+        </b-col>
+      </b-row>
+    </div>
+  </template>
+  
+  <script>
+  import permissionsMixin from '../../mixins/permissionsMixin';
+  import common from '@/shared/common';
+  import xssFilters from 'xss-filters';
+  import { loadUserPreferencesForBootstrapTable } from '@/shared/utils';
+  import { hasPermission } from '@/shared/permissions';
+  import * as permissions from '@/shared/permissions';
+  
+  export default {
+    mixins: [permissionsMixin],
+    computed: {
+      watchers() {
+        return [
+          this.showInactive,
+          this.showSuppressed,
+          this.violationStateSelected,
+          this.riskTypeSelected,
+          this.policySelected,
+          this.analysisStateSelected,
+          this.occurredOnDateFrom,
+          this.occurredOnDateTo,
+        ];
+      },
+    },
+    beforeMount() {
+      this.initializeWatchers();
+      this.initializePolicies();
+      this.textSearchSelected = this.textSearchOptions.map(
+        (option) => option.value,
+      );
+    },
+    methods: {
+      initializePolicies: function () {
+        let policyUrl = `${this.$api.BASE_URL}/${this.$api.URL_POLICY}`;
+        if (
+          hasPermission(permissions.POLICY_MANAGEMENT, this.decodedToken) ||
+          hasPermission(permissions.ACCESS_MANAGEMENT, this.decodedToken)
+        ) {
+          this.axios
+            .get(policyUrl)
+            .then((response) => {
+              if (response.data) {
+                response.data.forEach((policy) =>
+                  this.policyOptions.push({
+                    text: policy.name,
+                    value: policy.uuid,
+                  }),
+                );
+              }
+            })
+            .catch((error) => {
+              this.$toastr.w(this.$t('condition.unsuccessful_action'));
+            });
+        }
+      },
+      initializeWatchers: function () {
+        this.simpleWatcher = this.$watch('watchers', () => this.refreshTable());
+        this.textSearchSelectedWatcher = this.$watch('textSearchSelected', () => {
+          if (this.textSearchInput.trim().length !== 0) {
+            this.refreshTable();
+          }
+        });
+        this.textSearchInputWatcher = this.$watch(
+          'textSearchInput',
+          (newInput, oldInput) => {
+            if (!(newInput.trim().length === 0 && oldInput.trim().length === 0)) {
+              this.refreshTable();
+            }
+          },
+        );
+      },
+      apiUrl: function () {
+        let url = `${this.$api.BASE_URL}/${this.$api.URL_POLICY_VIOLATION}`;
+        url +=
+          '?showInactive=' +
+          (this.showInactive === 'true') +
+          '&suppressed=' +
+          (this.showSuppressed === 'true');
+        if (
+          this.violationStateSelected &&
+          this.violationStateSelected.length > 0
+        ) {
+          url += '&violationState=' + this.violationStateSelected;
+        }
+        if (this.riskTypeSelected && this.riskTypeSelected.length > 0) {
+          url += '&riskType=' + this.riskTypeSelected;
+        }
+        if (this.policySelected && this.policySelected.length > 0) {
+          url += '&policy=' + this.policySelected;
+        }
+        if (this.analysisStateSelected && this.analysisStateSelected.length > 0) {
+          url += '&analysisState=' + this.analysisStateSelected;
+        }
+        if (this.occurredOnDateFrom && this.occurredOnDateFrom.length > 0) {
+          url += '&occurredOnDateFrom=' + this.occurredOnDateFrom;
+        }
+        if (this.occurredOnDateTo && this.occurredOnDateTo.length > 0) {
+          url += '&occurredOnDateTo=' + this.occurredOnDateTo;
+        }
+        if (this.textSearchInput && this.textSearchInput.trim().length > 0) {
+          url +=
+            '&textSearchField=' +
+            this.textSearchSelected +
+            '&textSearchInput=' +
+            this.textSearchInput.trim();
+        }
+        return url;
+      },
+      clearAllFilters: function () {
+        this.simpleWatcher();
+        this.textSearchSelectedWatcher();
+        this.textSearchInputWatcher();
+        this.showInactive = false;
+        this.showSuppressed = false;
+        this.violationStateSelected = [];
+        this.riskTypeSelected = [];
+        this.policySelected = [];
+        this.analysisStateSelected = [];
+        this.occurredOnDateFrom = '';
+        this.occurredOnDateTo = '';
+        this.textSearchInput = '';
+        this.textSearchSelected = this.textSearchOptions.map(
+          (option) => option.value,
+        );
+        this.refreshTable();
+        this.initializeWatchers();
+      },
+      refreshTable: function () {
+        this.$refs.table.refresh({
+          url: this.apiUrl(),
+          silent: true,
+        });
+      },
+      onLoadSuccess: function () {
+        loadUserPreferencesForBootstrapTable(
+          this,
+          'PolicyViolationAudit',
+          this.$refs.table.columns,
+        );
+      },
+    },
+    data() {
+      return {
+        simpleWatcher: null,
+        textSearchSelectedWatcher: null,
+        textSearchInputWatcher: null,
+        showInactive: false,
+        showSuppressed: false,
+        violationStateSelected: [],
+        violationStateOptions: [
+          { text: 'Fail', value: 'FAIL' },
+          { text: 'Warn', value: 'WARN' },
+          { text: 'Info', value: 'INFO' },
+        ],
+        riskTypeSelected: [],
+        riskTypeOptions: [
+          { text: 'License', value: 'LICENSE' },
+          { text: 'Security', value: 'SECURITY' },
+          { text: 'Operational', value: 'OPERATIONAL' },
+        ],
+        policySelected: [],
+        policyOptions: [],
+        analysisStateSelected: [],
+        analysisStateOptions: [
+          { text: 'Not Set', value: 'NOT_SET' },
+          { text: 'Rejected', value: 'REJECTED' },
+          { text: 'Approved', value: 'APPROVED' },
+        ],
+        occurredOnDateFrom: '',
+        occurredOnDateTo: '',
+        textSearchInput: '',
+        textSearchOptions: [
+          { text: 'Policy Name', value: 'policy_name' },
+          { text: 'Component', value: 'component' },
+          { text: 'License', value: 'license' },
+          { text: 'Project Name', value: 'project_name' },
+        ],
+        textSearchSelected: [],
+        columns: [
+          {
+            title: this.$t('message.state'),
+            field: 'policyCondition.policy.violationState',
+            sortable: true,
+            class: 'tight',
+            formatter(value, row, index) {
+              if (typeof value !== 'undefined') {
+                return common.formatViolationStateLabel(value);
+              }
+            },
+          },
+          {
+            title: this.$t('message.risk_type'),
+            field: 'type',
+            sortable: true,
+            class: 'tight',
+            formatter(value, row, index) {
+              return xssFilters.inHTMLData(
+                common.capitalize(common.valueWithDefault(value, '')),
+              );
+            },
+          },
+          {
+            title: this.$t('message.policy_name'),
+            field: 'policyCondition.policy.name',
+            sortable: true,
+            formatter(value, row, index) {
+              return xssFilters.inHTMLData(common.valueWithDefault(value, ''));
+            },
+          },
+          {
+            title: this.$t('message.component'),
+            field: 'component.name',
+            sortable: true,
+            formatter: (value, row, index) => {
+              if (row.component) {
+                let url = xssFilters.uriInUnQuotedAttr(
+                  '../../../components/' + row.component.uuid,
+                );
+                let name = common.concatenateComponentName(
+                  null,
+                  row.component.name,
+                  row.component.version,
+                );
+                let dependencyGraphUrl = xssFilters.uriInUnQuotedAttr(
+                  '../../../projects/' +
+                    row.project.uuid +
+                    '/dependencyGraph/' +
+                    row.component.uuid,
+                );
+                return (
+                  `<a href="${dependencyGraphUrl}"<i class="fa fa-sitemap" aria-hidden="true" style="float:right; padding-top: 4px; cursor:pointer" data-toggle="tooltip" data-placement="bottom" title="Show in dependency graph"></i></a> ` +
+                  `<a href="${url}">${xssFilters.inHTMLData(name)}</a>`
+                );
+              } else {
+                return '';
+              }
+            },
+          },
+          {
+            title: this.$t('message.project_name'),
+            field: 'project.name',
+            sortable: true,
+            formatter(value, row, index) {
+              let url = xssFilters.uriInUnQuotedAttr(
+                '../projects/' + row.project.uuid,
+              );
+              let name = common.concatenateComponentName(
+                null,
+                row.project.name,
+                row.project.version,
+              );
+              return `<a href="${url}">${xssFilters.inHTMLData(name)}</a>`;
+            },
+          },
+          {
+            title: this.$t('message.occurred_on'),
+            field: 'timestamp',
+            sortable: true,
+            formatter(value, row, index) {
+              return xssFilters.inHTMLData(common.formatTimestamp(value));
+            },
+          },
+          {
+            title: this.$t('message.analysis'),
+            field: 'analysis.analysisState',
+            sortable: false,
+            formatter: common.makeAnalysisStateLabelFormatter(this),
+          },
+          {
+            title: this.$t('message.suppressed'),
+            field: 'analysis.isSuppressed',
+            sortable: false,
+            class: 'tight',
+            formatter(value, row, index) {
+              return value === true ? '<i class="fa fa-check-square-o" />' : '';
+            },
+          },
+          {
+            title: this.$t('message.license'),
+            field: 'component.license',
+            sortable: true,
+            formatter(value, row, index) {
+              if (
+                Object.prototype.hasOwnProperty.call(
+                  row.component,
+                  'resolvedLicense',
+                )
+              ) {
+                let licenseurl =
+                  '../../../licenses/' + row.component.resolvedLicense.licenseId;
+                return (
+                  '<a href="' +
+                  licenseurl +
+                  '">' +
+                  xssFilters.inHTMLData(row.component.resolvedLicense.licenseId) +
+                  '</a>'
+                );
+              } else {
+                return xssFilters.inHTMLData(common.valueWithDefault(value, ''));
+              }
+            },
+          },
+        ],
+        data: [],
+        options: {
+          search: false,
+          showColumns: true,
+          showRefresh: true,
+          pagination: true,
+          silentSort: false,
+          sidePagination: 'server',
+          queryParamsType: 'pageSize',
+          pageList: '[10, 25, 50, 100]',
+          pageSize:
+            localStorage &&
+            localStorage.getItem('PolicyViolationAuditPageSize') !== null
+              ? Number(localStorage.getItem('PolicyViolationAuditPageSize'))
+              : 10,
+          sortName:
+            localStorage &&
+            localStorage.getItem('PolicyViolationAuditSortName') !== null
+              ? localStorage.getItem('PolicyViolationAuditSortName')
+              : 'timestamp',
+          sortOrder:
+            localStorage &&
+            localStorage.getItem('PolicyViolationAuditSortOrder') !== null
+              ? localStorage.getItem('PolicyViolationAuditSortOrder')
+              : 'desc',
+          icons: {
+            refresh: 'fa-refresh',
+          },
+          responseHandler: function (res, xhr) {
+            res.total = xhr.getResponseHeader('X-Total-Count');
+            return res;
+          },
+          url: this.apiUrl(),
+          onPageChange: (number, size) => {
+            if (localStorage) {
+              localStorage.setItem(
+                'PolicyViolationAuditPageSize',
+                size.toString(),
+              );
+            }
+          },
+          onColumnSwitch: (field, checked) => {
+            if (localStorage) {
+              localStorage.setItem(
+                'PolicyViolationAuditShow' + common.capitalize(field),
+                checked.toString(),
+              );
+            }
+          },
+          onSort: (name, order) => {
+            if (localStorage) {
+              localStorage.setItem('PolicyViolationAuditSortName', name);
+              localStorage.setItem('PolicyViolationAuditSortOrder', order);
+            }
+          },
+        },
+      };
+    },
+  };
+  </script>

--- a/src/views/audit/PolicyViolationAudit.vue
+++ b/src/views/audit/PolicyViolationAudit.vue
@@ -1,505 +1,505 @@
 <template>
-    <div class="animated fadeIn" v-permission="PERMISSIONS.VIEW_POLICY_VIOLATION">
-      <b-row>
-        <b-col xs="6" sm="4" md="4" lg="2" id="filter-controls">
-          <div>
-            <h3 style="display: inline">{{ this.$t('message.filters') }}</h3>
-            <b-button
-              size="md"
-              variant="outline-primary"
-              style="float: right"
-              @click="clearAllFilters()"
-            >
-              {{ this.$t('message.clear_all') }}</b-button
-            >
-            <br /><br />
-            <b-form-group
-              id="showInactive-form-group"
-              :label="this.$t('message.projects')"
-            >
-              <b-form-checkbox
-                id="showInactive-form-checkbox"
-                v-model="showInactive"
-                value="true"
-                unchecked-value="false"
-              >
-                {{ this.$t('message.show_inactive_projects') }}
-              </b-form-checkbox>
-            </b-form-group>
-            <b-form-group
-              id="showSuppressed-form-group"
-              :label="this.$t('message.analysis_status')"
-            >
-              <b-form-checkbox
-                id="showSuppressed-form-checkbox"
-                v-model="showSuppressed"
-                value="true"
-                unchecked-value="false"
-              >
-                {{ this.$t('message.show_suppressed_violations') }}
-              </b-form-checkbox>
-            </b-form-group>
-            <b-form-group
-              id="violation-state-form-group"
-              :label="this.$t('message.violation_state')"
-            >
-              <b-form-checkbox-group
-                id="violation-state-form-checkbox-group"
-                v-model="violationStateSelected"
-                :options="violationStateOptions"
-                stacked
-              >
-              </b-form-checkbox-group>
-            </b-form-group>
-            <b-form-group
-              id="risk-type-form-group"
-              :label="this.$t('message.risk_type')"
-            >
-              <b-form-checkbox-group
-                id="risk-type-form-checkbox-group"
-                v-model="riskTypeSelected"
-                :options="riskTypeOptions"
-                stacked
-              >
-              </b-form-checkbox-group>
-            </b-form-group>
-            <b-form-group
-              id="analysis-type-form-group"
-              :label="this.$t('message.analysis_state')"
-            >
-              <b-form-checkbox-group
-                id="analysis-type-form-checkbox-group"
-                v-model="analysisStateSelected"
-                :options="analysisStateOptions"
-                stacked
-              >
-              </b-form-checkbox-group>
-            </b-form-group>
-            <b-form-group
-              id="occurred-on-date-form-group"
-              :label="this.$t('message.occurred_on')"
-            >
-              <b-datepicker
-                id="occurred-on-datepicker-from"
-                v-model="occurredOnDateFrom"
-                :max="occurredOnDateTo"
-                :placeholder="this.$t('message.from')"
-              ></b-datepicker>
-              <b-datepicker
-                id="occurred-on-datepicker-to"
-                v-model="occurredOnDateTo"
-                :min="occurredOnDateFrom"
-                :placeholder="this.$t('message.to')"
-              ></b-datepicker>
-            </b-form-group>
-            <b-form-group
-              id="text-search-form-group"
-              :label="this.$t('message.text_search')"
-            >
-              <b-form-input
-                id="text-search-form-input"
-                v-model="textSearchInput"
-                debounce="750"
-                :placeholder="this.$t('message.search')"
-              ></b-form-input>
-              Search in:
-              <b-form-checkbox-group
-                id="text-search-form-checkbox-group"
-                v-model="textSearchSelected"
-                :options="textSearchOptions"
-                stacked
-              >
-              </b-form-checkbox-group>
-            </b-form-group>
-            <b-form-group
-              id="policy-form-group"
-              :label="this.$t('message.policies')"
-              v-permission="PERMISSIONS.POLICY_MANAGEMENT"
-            >
-              <b-form-checkbox-group
-                id="policy-form-checkbox-group"
-                v-model="policySelected"
-                :options="policyOptions"
-                stacked
-              >
-              </b-form-checkbox-group>
-            </b-form-group>
-          </div>
-        </b-col>
-        <b-col xs="6" sm="8" md="8" lg="10">
-          <bootstrap-table
-            ref="table"
-            :columns="columns"
-            :data="data"
-            :options="options"
-            @on-load-success="onLoadSuccess"
+  <div class="animated fadeIn" v-permission="PERMISSIONS.VIEW_POLICY_VIOLATION">
+    <b-row>
+      <b-col xs="6" sm="4" md="4" lg="2" id="filter-controls">
+        <div>
+          <h3 style="display: inline">{{ this.$t('message.filters') }}</h3>
+          <b-button
+            size="md"
+            variant="outline-primary"
+            style="float: right"
+            @click="clearAllFilters()"
           >
-          </bootstrap-table>
-        </b-col>
-      </b-row>
-    </div>
-  </template>
-  
-  <script>
-  import permissionsMixin from '../../mixins/permissionsMixin';
-  import common from '@/shared/common';
-  import xssFilters from 'xss-filters';
-  import { loadUserPreferencesForBootstrapTable } from '@/shared/utils';
-  import { hasPermission } from '@/shared/permissions';
-  import * as permissions from '@/shared/permissions';
-  
-  export default {
-    mixins: [permissionsMixin],
-    computed: {
-      watchers() {
-        return [
-          this.showInactive,
-          this.showSuppressed,
-          this.violationStateSelected,
-          this.riskTypeSelected,
-          this.policySelected,
-          this.analysisStateSelected,
-          this.occurredOnDateFrom,
-          this.occurredOnDateTo,
-        ];
-      },
+            {{ this.$t('message.clear_all') }}</b-button
+          >
+          <br /><br />
+          <b-form-group
+            id="showInactive-form-group"
+            :label="this.$t('message.projects')"
+          >
+            <b-form-checkbox
+              id="showInactive-form-checkbox"
+              v-model="showInactive"
+              value="true"
+              unchecked-value="false"
+            >
+              {{ this.$t('message.show_inactive_projects') }}
+            </b-form-checkbox>
+          </b-form-group>
+          <b-form-group
+            id="showSuppressed-form-group"
+            :label="this.$t('message.analysis_status')"
+          >
+            <b-form-checkbox
+              id="showSuppressed-form-checkbox"
+              v-model="showSuppressed"
+              value="true"
+              unchecked-value="false"
+            >
+              {{ this.$t('message.show_suppressed_violations') }}
+            </b-form-checkbox>
+          </b-form-group>
+          <b-form-group
+            id="violation-state-form-group"
+            :label="this.$t('message.violation_state')"
+          >
+            <b-form-checkbox-group
+              id="violation-state-form-checkbox-group"
+              v-model="violationStateSelected"
+              :options="violationStateOptions"
+              stacked
+            >
+            </b-form-checkbox-group>
+          </b-form-group>
+          <b-form-group
+            id="risk-type-form-group"
+            :label="this.$t('message.risk_type')"
+          >
+            <b-form-checkbox-group
+              id="risk-type-form-checkbox-group"
+              v-model="riskTypeSelected"
+              :options="riskTypeOptions"
+              stacked
+            >
+            </b-form-checkbox-group>
+          </b-form-group>
+          <b-form-group
+            id="analysis-type-form-group"
+            :label="this.$t('message.analysis_state')"
+          >
+            <b-form-checkbox-group
+              id="analysis-type-form-checkbox-group"
+              v-model="analysisStateSelected"
+              :options="analysisStateOptions"
+              stacked
+            >
+            </b-form-checkbox-group>
+          </b-form-group>
+          <b-form-group
+            id="occurred-on-date-form-group"
+            :label="this.$t('message.occurred_on')"
+          >
+            <b-datepicker
+              id="occurred-on-datepicker-from"
+              v-model="occurredOnDateFrom"
+              :max="occurredOnDateTo"
+              :placeholder="this.$t('message.from')"
+            ></b-datepicker>
+            <b-datepicker
+              id="occurred-on-datepicker-to"
+              v-model="occurredOnDateTo"
+              :min="occurredOnDateFrom"
+              :placeholder="this.$t('message.to')"
+            ></b-datepicker>
+          </b-form-group>
+          <b-form-group
+            id="text-search-form-group"
+            :label="this.$t('message.text_search')"
+          >
+            <b-form-input
+              id="text-search-form-input"
+              v-model="textSearchInput"
+              debounce="750"
+              :placeholder="this.$t('message.search')"
+            ></b-form-input>
+            Search in:
+            <b-form-checkbox-group
+              id="text-search-form-checkbox-group"
+              v-model="textSearchSelected"
+              :options="textSearchOptions"
+              stacked
+            >
+            </b-form-checkbox-group>
+          </b-form-group>
+          <b-form-group
+            id="policy-form-group"
+            :label="this.$t('message.policies')"
+            v-permission="PERMISSIONS.POLICY_MANAGEMENT"
+          >
+            <b-form-checkbox-group
+              id="policy-form-checkbox-group"
+              v-model="policySelected"
+              :options="policyOptions"
+              stacked
+            >
+            </b-form-checkbox-group>
+          </b-form-group>
+        </div>
+      </b-col>
+      <b-col xs="6" sm="8" md="8" lg="10">
+        <bootstrap-table
+          ref="table"
+          :columns="columns"
+          :data="data"
+          :options="options"
+          @on-load-success="onLoadSuccess"
+        >
+        </bootstrap-table>
+      </b-col>
+    </b-row>
+  </div>
+</template>
+
+<script>
+import permissionsMixin from '../../mixins/permissionsMixin';
+import common from '@/shared/common';
+import xssFilters from 'xss-filters';
+import { loadUserPreferencesForBootstrapTable } from '@/shared/utils';
+import { hasPermission } from '@/shared/permissions';
+import * as permissions from '@/shared/permissions';
+
+export default {
+  mixins: [permissionsMixin],
+  computed: {
+    watchers() {
+      return [
+        this.showInactive,
+        this.showSuppressed,
+        this.violationStateSelected,
+        this.riskTypeSelected,
+        this.policySelected,
+        this.analysisStateSelected,
+        this.occurredOnDateFrom,
+        this.occurredOnDateTo,
+      ];
     },
-    beforeMount() {
-      this.initializeWatchers();
-      this.initializePolicies();
+  },
+  beforeMount() {
+    this.initializeWatchers();
+    this.initializePolicies();
+    this.textSearchSelected = this.textSearchOptions.map(
+      (option) => option.value,
+    );
+  },
+  methods: {
+    initializePolicies: function () {
+      let policyUrl = `${this.$api.BASE_URL}/${this.$api.URL_POLICY}`;
+      if (
+        hasPermission(permissions.POLICY_MANAGEMENT, this.decodedToken) ||
+        hasPermission(permissions.ACCESS_MANAGEMENT, this.decodedToken)
+      ) {
+        this.axios
+          .get(policyUrl)
+          .then((response) => {
+            if (response.data) {
+              response.data.forEach((policy) =>
+                this.policyOptions.push({
+                  text: policy.name,
+                  value: policy.uuid,
+                }),
+              );
+            }
+          })
+          .catch((error) => {
+            this.$toastr.w(this.$t('condition.unsuccessful_action'));
+          });
+      }
+    },
+    initializeWatchers: function () {
+      this.simpleWatcher = this.$watch('watchers', () => this.refreshTable());
+      this.textSearchSelectedWatcher = this.$watch('textSearchSelected', () => {
+        if (this.textSearchInput.trim().length !== 0) {
+          this.refreshTable();
+        }
+      });
+      this.textSearchInputWatcher = this.$watch(
+        'textSearchInput',
+        (newInput, oldInput) => {
+          if (!(newInput.trim().length === 0 && oldInput.trim().length === 0)) {
+            this.refreshTable();
+          }
+        },
+      );
+    },
+    apiUrl: function () {
+      let url = `${this.$api.BASE_URL}/${this.$api.URL_POLICY_VIOLATION}`;
+      url +=
+        '?showInactive=' +
+        (this.showInactive === 'true') +
+        '&suppressed=' +
+        (this.showSuppressed === 'true');
+      if (
+        this.violationStateSelected &&
+        this.violationStateSelected.length > 0
+      ) {
+        url += '&violationState=' + this.violationStateSelected;
+      }
+      if (this.riskTypeSelected && this.riskTypeSelected.length > 0) {
+        url += '&riskType=' + this.riskTypeSelected;
+      }
+      if (this.policySelected && this.policySelected.length > 0) {
+        url += '&policy=' + this.policySelected;
+      }
+      if (this.analysisStateSelected && this.analysisStateSelected.length > 0) {
+        url += '&analysisState=' + this.analysisStateSelected;
+      }
+      if (this.occurredOnDateFrom && this.occurredOnDateFrom.length > 0) {
+        url += '&occurredOnDateFrom=' + this.occurredOnDateFrom;
+      }
+      if (this.occurredOnDateTo && this.occurredOnDateTo.length > 0) {
+        url += '&occurredOnDateTo=' + this.occurredOnDateTo;
+      }
+      if (this.textSearchInput && this.textSearchInput.trim().length > 0) {
+        url +=
+          '&textSearchField=' +
+          this.textSearchSelected +
+          '&textSearchInput=' +
+          this.textSearchInput.trim();
+      }
+      return url;
+    },
+    clearAllFilters: function () {
+      this.simpleWatcher();
+      this.textSearchSelectedWatcher();
+      this.textSearchInputWatcher();
+      this.showInactive = false;
+      this.showSuppressed = false;
+      this.violationStateSelected = [];
+      this.riskTypeSelected = [];
+      this.policySelected = [];
+      this.analysisStateSelected = [];
+      this.occurredOnDateFrom = '';
+      this.occurredOnDateTo = '';
+      this.textSearchInput = '';
       this.textSearchSelected = this.textSearchOptions.map(
         (option) => option.value,
       );
+      this.refreshTable();
+      this.initializeWatchers();
     },
-    methods: {
-      initializePolicies: function () {
-        let policyUrl = `${this.$api.BASE_URL}/${this.$api.URL_POLICY}`;
-        if (
-          hasPermission(permissions.POLICY_MANAGEMENT, this.decodedToken) ||
-          hasPermission(permissions.ACCESS_MANAGEMENT, this.decodedToken)
-        ) {
-          this.axios
-            .get(policyUrl)
-            .then((response) => {
-              if (response.data) {
-                response.data.forEach((policy) =>
-                  this.policyOptions.push({
-                    text: policy.name,
-                    value: policy.uuid,
-                  }),
-                );
-              }
-            })
-            .catch((error) => {
-              this.$toastr.w(this.$t('condition.unsuccessful_action'));
-            });
-        }
-      },
-      initializeWatchers: function () {
-        this.simpleWatcher = this.$watch('watchers', () => this.refreshTable());
-        this.textSearchSelectedWatcher = this.$watch('textSearchSelected', () => {
-          if (this.textSearchInput.trim().length !== 0) {
-            this.refreshTable();
-          }
-        });
-        this.textSearchInputWatcher = this.$watch(
-          'textSearchInput',
-          (newInput, oldInput) => {
-            if (!(newInput.trim().length === 0 && oldInput.trim().length === 0)) {
-              this.refreshTable();
-            }
-          },
-        );
-      },
-      apiUrl: function () {
-        let url = `${this.$api.BASE_URL}/${this.$api.URL_POLICY_VIOLATION}`;
-        url +=
-          '?showInactive=' +
-          (this.showInactive === 'true') +
-          '&suppressed=' +
-          (this.showSuppressed === 'true');
-        if (
-          this.violationStateSelected &&
-          this.violationStateSelected.length > 0
-        ) {
-          url += '&violationState=' + this.violationStateSelected;
-        }
-        if (this.riskTypeSelected && this.riskTypeSelected.length > 0) {
-          url += '&riskType=' + this.riskTypeSelected;
-        }
-        if (this.policySelected && this.policySelected.length > 0) {
-          url += '&policy=' + this.policySelected;
-        }
-        if (this.analysisStateSelected && this.analysisStateSelected.length > 0) {
-          url += '&analysisState=' + this.analysisStateSelected;
-        }
-        if (this.occurredOnDateFrom && this.occurredOnDateFrom.length > 0) {
-          url += '&occurredOnDateFrom=' + this.occurredOnDateFrom;
-        }
-        if (this.occurredOnDateTo && this.occurredOnDateTo.length > 0) {
-          url += '&occurredOnDateTo=' + this.occurredOnDateTo;
-        }
-        if (this.textSearchInput && this.textSearchInput.trim().length > 0) {
-          url +=
-            '&textSearchField=' +
-            this.textSearchSelected +
-            '&textSearchInput=' +
-            this.textSearchInput.trim();
-        }
-        return url;
-      },
-      clearAllFilters: function () {
-        this.simpleWatcher();
-        this.textSearchSelectedWatcher();
-        this.textSearchInputWatcher();
-        this.showInactive = false;
-        this.showSuppressed = false;
-        this.violationStateSelected = [];
-        this.riskTypeSelected = [];
-        this.policySelected = [];
-        this.analysisStateSelected = [];
-        this.occurredOnDateFrom = '';
-        this.occurredOnDateTo = '';
-        this.textSearchInput = '';
-        this.textSearchSelected = this.textSearchOptions.map(
-          (option) => option.value,
-        );
-        this.refreshTable();
-        this.initializeWatchers();
-      },
-      refreshTable: function () {
-        this.$refs.table.refresh({
-          url: this.apiUrl(),
-          silent: true,
-        });
-      },
-      onLoadSuccess: function () {
-        loadUserPreferencesForBootstrapTable(
-          this,
-          'PolicyViolationAudit',
-          this.$refs.table.columns,
-        );
-      },
+    refreshTable: function () {
+      this.$refs.table.refresh({
+        url: this.apiUrl(),
+        silent: true,
+      });
     },
-    data() {
-      return {
-        simpleWatcher: null,
-        textSearchSelectedWatcher: null,
-        textSearchInputWatcher: null,
-        showInactive: false,
-        showSuppressed: false,
-        violationStateSelected: [],
-        violationStateOptions: [
-          { text: 'Fail', value: 'FAIL' },
-          { text: 'Warn', value: 'WARN' },
-          { text: 'Info', value: 'INFO' },
-        ],
-        riskTypeSelected: [],
-        riskTypeOptions: [
-          { text: 'License', value: 'LICENSE' },
-          { text: 'Security', value: 'SECURITY' },
-          { text: 'Operational', value: 'OPERATIONAL' },
-        ],
-        policySelected: [],
-        policyOptions: [],
-        analysisStateSelected: [],
-        analysisStateOptions: [
-          { text: 'Not Set', value: 'NOT_SET' },
-          { text: 'Rejected', value: 'REJECTED' },
-          { text: 'Approved', value: 'APPROVED' },
-        ],
-        occurredOnDateFrom: '',
-        occurredOnDateTo: '',
-        textSearchInput: '',
-        textSearchOptions: [
-          { text: 'Policy Name', value: 'policy_name' },
-          { text: 'Component', value: 'component' },
-          { text: 'License', value: 'license' },
-          { text: 'Project Name', value: 'project_name' },
-        ],
-        textSearchSelected: [],
-        columns: [
-          {
-            title: this.$t('message.state'),
-            field: 'policyCondition.policy.violationState',
-            sortable: true,
-            class: 'tight',
-            formatter(value, row, index) {
-              if (typeof value !== 'undefined') {
-                return common.formatViolationStateLabel(value);
-              }
-            },
-          },
-          {
-            title: this.$t('message.risk_type'),
-            field: 'type',
-            sortable: true,
-            class: 'tight',
-            formatter(value, row, index) {
-              return xssFilters.inHTMLData(
-                common.capitalize(common.valueWithDefault(value, '')),
-              );
-            },
-          },
-          {
-            title: this.$t('message.policy_name'),
-            field: 'policyCondition.policy.name',
-            sortable: true,
-            formatter(value, row, index) {
-              return xssFilters.inHTMLData(common.valueWithDefault(value, ''));
-            },
-          },
-          {
-            title: this.$t('message.component'),
-            field: 'component.name',
-            sortable: true,
-            formatter: (value, row, index) => {
-              if (row.component) {
-                let url = xssFilters.uriInUnQuotedAttr(
-                  '../../../components/' + row.component.uuid,
-                );
-                let name = common.concatenateComponentName(
-                  null,
-                  row.component.name,
-                  row.component.version,
-                );
-                let dependencyGraphUrl = xssFilters.uriInUnQuotedAttr(
-                  '../../../projects/' +
-                    row.project.uuid +
-                    '/dependencyGraph/' +
-                    row.component.uuid,
-                );
-                return (
-                  `<a href="${dependencyGraphUrl}"<i class="fa fa-sitemap" aria-hidden="true" style="float:right; padding-top: 4px; cursor:pointer" data-toggle="tooltip" data-placement="bottom" title="Show in dependency graph"></i></a> ` +
-                  `<a href="${url}">${xssFilters.inHTMLData(name)}</a>`
-                );
-              } else {
-                return '';
-              }
-            },
-          },
-          {
-            title: this.$t('message.project_name'),
-            field: 'project.name',
-            sortable: true,
-            formatter(value, row, index) {
-              let url = xssFilters.uriInUnQuotedAttr(
-                '../projects/' + row.project.uuid,
-              );
-              let name = common.concatenateComponentName(
-                null,
-                row.project.name,
-                row.project.version,
-              );
-              return `<a href="${url}">${xssFilters.inHTMLData(name)}</a>`;
-            },
-          },
-          {
-            title: this.$t('message.occurred_on'),
-            field: 'timestamp',
-            sortable: true,
-            formatter(value, row, index) {
-              return xssFilters.inHTMLData(common.formatTimestamp(value));
-            },
-          },
-          {
-            title: this.$t('message.analysis'),
-            field: 'analysis.analysisState',
-            sortable: false,
-            formatter: common.makeAnalysisStateLabelFormatter(this),
-          },
-          {
-            title: this.$t('message.suppressed'),
-            field: 'analysis.isSuppressed',
-            sortable: false,
-            class: 'tight',
-            formatter(value, row, index) {
-              return value === true ? '<i class="fa fa-check-square-o" />' : '';
-            },
-          },
-          {
-            title: this.$t('message.license'),
-            field: 'component.license',
-            sortable: true,
-            formatter(value, row, index) {
-              if (
-                Object.prototype.hasOwnProperty.call(
-                  row.component,
-                  'resolvedLicense',
-                )
-              ) {
-                let licenseurl =
-                  '../../../licenses/' + row.component.resolvedLicense.licenseId;
-                return (
-                  '<a href="' +
-                  licenseurl +
-                  '">' +
-                  xssFilters.inHTMLData(row.component.resolvedLicense.licenseId) +
-                  '</a>'
-                );
-              } else {
-                return xssFilters.inHTMLData(common.valueWithDefault(value, ''));
-              }
-            },
-          },
-        ],
-        data: [],
-        options: {
-          search: false,
-          showColumns: true,
-          showRefresh: true,
-          pagination: true,
-          silentSort: false,
-          sidePagination: 'server',
-          queryParamsType: 'pageSize',
-          pageList: '[10, 25, 50, 100]',
-          pageSize:
-            localStorage &&
-            localStorage.getItem('PolicyViolationAuditPageSize') !== null
-              ? Number(localStorage.getItem('PolicyViolationAuditPageSize'))
-              : 10,
-          sortName:
-            localStorage &&
-            localStorage.getItem('PolicyViolationAuditSortName') !== null
-              ? localStorage.getItem('PolicyViolationAuditSortName')
-              : 'timestamp',
-          sortOrder:
-            localStorage &&
-            localStorage.getItem('PolicyViolationAuditSortOrder') !== null
-              ? localStorage.getItem('PolicyViolationAuditSortOrder')
-              : 'desc',
-          icons: {
-            refresh: 'fa-refresh',
-          },
-          responseHandler: function (res, xhr) {
-            res.total = xhr.getResponseHeader('X-Total-Count');
-            return res;
-          },
-          url: this.apiUrl(),
-          onPageChange: (number, size) => {
-            if (localStorage) {
-              localStorage.setItem(
-                'PolicyViolationAuditPageSize',
-                size.toString(),
-              );
-            }
-          },
-          onColumnSwitch: (field, checked) => {
-            if (localStorage) {
-              localStorage.setItem(
-                'PolicyViolationAuditShow' + common.capitalize(field),
-                checked.toString(),
-              );
-            }
-          },
-          onSort: (name, order) => {
-            if (localStorage) {
-              localStorage.setItem('PolicyViolationAuditSortName', name);
-              localStorage.setItem('PolicyViolationAuditSortOrder', order);
+    onLoadSuccess: function () {
+      loadUserPreferencesForBootstrapTable(
+        this,
+        'PolicyViolationAudit',
+        this.$refs.table.columns,
+      );
+    },
+  },
+  data() {
+    return {
+      simpleWatcher: null,
+      textSearchSelectedWatcher: null,
+      textSearchInputWatcher: null,
+      showInactive: false,
+      showSuppressed: false,
+      violationStateSelected: [],
+      violationStateOptions: [
+        { text: 'Fail', value: 'FAIL' },
+        { text: 'Warn', value: 'WARN' },
+        { text: 'Info', value: 'INFO' },
+      ],
+      riskTypeSelected: [],
+      riskTypeOptions: [
+        { text: 'License', value: 'LICENSE' },
+        { text: 'Security', value: 'SECURITY' },
+        { text: 'Operational', value: 'OPERATIONAL' },
+      ],
+      policySelected: [],
+      policyOptions: [],
+      analysisStateSelected: [],
+      analysisStateOptions: [
+        { text: 'Not Set', value: 'NOT_SET' },
+        { text: 'Rejected', value: 'REJECTED' },
+        { text: 'Approved', value: 'APPROVED' },
+      ],
+      occurredOnDateFrom: '',
+      occurredOnDateTo: '',
+      textSearchInput: '',
+      textSearchOptions: [
+        { text: 'Policy Name', value: 'policy_name' },
+        { text: 'Component', value: 'component' },
+        { text: 'License', value: 'license' },
+        { text: 'Project Name', value: 'project_name' },
+      ],
+      textSearchSelected: [],
+      columns: [
+        {
+          title: this.$t('message.state'),
+          field: 'policyCondition.policy.violationState',
+          sortable: true,
+          class: 'tight',
+          formatter(value, row, index) {
+            if (typeof value !== 'undefined') {
+              return common.formatViolationStateLabel(value);
             }
           },
         },
-      };
-    },
-  };
-  </script>
+        {
+          title: this.$t('message.risk_type'),
+          field: 'type',
+          sortable: true,
+          class: 'tight',
+          formatter(value, row, index) {
+            return xssFilters.inHTMLData(
+              common.capitalize(common.valueWithDefault(value, '')),
+            );
+          },
+        },
+        {
+          title: this.$t('message.policy_name'),
+          field: 'policyCondition.policy.name',
+          sortable: true,
+          formatter(value, row, index) {
+            return xssFilters.inHTMLData(common.valueWithDefault(value, ''));
+          },
+        },
+        {
+          title: this.$t('message.component'),
+          field: 'component.name',
+          sortable: true,
+          formatter: (value, row, index) => {
+            if (row.component) {
+              let url = xssFilters.uriInUnQuotedAttr(
+                '../../../components/' + row.component.uuid,
+              );
+              let name = common.concatenateComponentName(
+                null,
+                row.component.name,
+                row.component.version,
+              );
+              let dependencyGraphUrl = xssFilters.uriInUnQuotedAttr(
+                '../../../projects/' +
+                  row.project.uuid +
+                  '/dependencyGraph/' +
+                  row.component.uuid,
+              );
+              return (
+                `<a href="${dependencyGraphUrl}"<i class="fa fa-sitemap" aria-hidden="true" style="float:right; padding-top: 4px; cursor:pointer" data-toggle="tooltip" data-placement="bottom" title="Show in dependency graph"></i></a> ` +
+                `<a href="${url}">${xssFilters.inHTMLData(name)}</a>`
+              );
+            } else {
+              return '';
+            }
+          },
+        },
+        {
+          title: this.$t('message.project_name'),
+          field: 'project.name',
+          sortable: true,
+          formatter(value, row, index) {
+            let url = xssFilters.uriInUnQuotedAttr(
+              '../projects/' + row.project.uuid,
+            );
+            let name = common.concatenateComponentName(
+              null,
+              row.project.name,
+              row.project.version,
+            );
+            return `<a href="${url}">${xssFilters.inHTMLData(name)}</a>`;
+          },
+        },
+        {
+          title: this.$t('message.occurred_on'),
+          field: 'timestamp',
+          sortable: true,
+          formatter(value, row, index) {
+            return xssFilters.inHTMLData(common.formatTimestamp(value));
+          },
+        },
+        {
+          title: this.$t('message.analysis'),
+          field: 'analysis.analysisState',
+          sortable: false,
+          formatter: common.makeAnalysisStateLabelFormatter(this),
+        },
+        {
+          title: this.$t('message.suppressed'),
+          field: 'analysis.isSuppressed',
+          sortable: false,
+          class: 'tight',
+          formatter(value, row, index) {
+            return value === true ? '<i class="fa fa-check-square-o" />' : '';
+          },
+        },
+        {
+          title: this.$t('message.license'),
+          field: 'component.license',
+          sortable: true,
+          formatter(value, row, index) {
+            if (
+              Object.prototype.hasOwnProperty.call(
+                row.component,
+                'resolvedLicense',
+              )
+            ) {
+              let licenseurl =
+                '../../../licenses/' + row.component.resolvedLicense.licenseId;
+              return (
+                '<a href="' +
+                licenseurl +
+                '">' +
+                xssFilters.inHTMLData(row.component.resolvedLicense.licenseId) +
+                '</a>'
+              );
+            } else {
+              return xssFilters.inHTMLData(common.valueWithDefault(value, ''));
+            }
+          },
+        },
+      ],
+      data: [],
+      options: {
+        search: false,
+        showColumns: true,
+        showRefresh: true,
+        pagination: true,
+        silentSort: false,
+        sidePagination: 'server',
+        queryParamsType: 'pageSize',
+        pageList: '[10, 25, 50, 100]',
+        pageSize:
+          localStorage &&
+          localStorage.getItem('PolicyViolationAuditPageSize') !== null
+            ? Number(localStorage.getItem('PolicyViolationAuditPageSize'))
+            : 10,
+        sortName:
+          localStorage &&
+          localStorage.getItem('PolicyViolationAuditSortName') !== null
+            ? localStorage.getItem('PolicyViolationAuditSortName')
+            : 'timestamp',
+        sortOrder:
+          localStorage &&
+          localStorage.getItem('PolicyViolationAuditSortOrder') !== null
+            ? localStorage.getItem('PolicyViolationAuditSortOrder')
+            : 'desc',
+        icons: {
+          refresh: 'fa-refresh',
+        },
+        responseHandler: function (res, xhr) {
+          res.total = xhr.getResponseHeader('X-Total-Count');
+          return res;
+        },
+        url: this.apiUrl(),
+        onPageChange: (number, size) => {
+          if (localStorage) {
+            localStorage.setItem(
+              'PolicyViolationAuditPageSize',
+              size.toString(),
+            );
+          }
+        },
+        onColumnSwitch: (field, checked) => {
+          if (localStorage) {
+            localStorage.setItem(
+              'PolicyViolationAuditShow' + common.capitalize(field),
+              checked.toString(),
+            );
+          }
+        },
+        onSort: (name, order) => {
+          if (localStorage) {
+            localStorage.setItem('PolicyViolationAuditSortName', name);
+            localStorage.setItem('PolicyViolationAuditSortOrder', order);
+          }
+        },
+      },
+    };
+  },
+};
+</script>


### PR DESCRIPTION
### Description

This PR introduces the new view Policy Violation Audit in the sidebar.

This view displays a list of all policy violations filtered by ACLs and other optional filters, making it easier to get an overview of all policy violations in one's projects with the possibility to filter them and only show relevant violations (e.g. Violation State = FAIL).

### Addressed Issue

Port change https://github.com/DependencyTrack/hyades/issues/1358
Backend PR : https://github.com/DependencyTrack/hyades-apiserver/pull/949

### Additional Details

<img width="1512" alt="Screenshot 2024-10-10 at 13 38 30" src="https://github.com/user-attachments/assets/103dd241-019a-44a7-a5f5-cb0914650ac4">

### Checklist

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/hyades/blob/main/CONTRIBUTING.md#pull-requests)
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://dependencytrack.github.io/hyades/latest/development/documentation/) accordingly
