### PR TITLE
Port: Fix state of sidebar not being saved for non-`SNAPSHOT` versions

### DIFF
--- a/src/containers/DefaultContainer.vue
+++ b/src/containers/DefaultContainer.vue
@@ -211,29 +211,26 @@ export default {
   mounted() {
     if (this.$dtrack && this.$dtrack.version.includes('SNAPSHOT')) {
       this.$root.$emit('bv::show::modal', 'snapshotModal');
-
-      this.isSidebarMinimized =
-        localStorage && localStorage.getItem('isSidebarMinimized') !== null
-          ? localStorage.getItem('isSidebarMinimized') === 'true'
-          : false;
-      const sidebar = document.body;
-      if (sidebar) {
-        if (this.isSidebarMinimized) {
-          sidebar.classList.add('sidebar-minimized');
-        } else {
-          sidebar.classList.remove('sidebar-minimized');
-        }
-      }
-      this.$nextTick(() => {
-        const sidebarMinimizer = this.$el.querySelector('.sidebar-minimizer');
-        if (sidebarMinimizer) {
-          sidebarMinimizer.addEventListener(
-            'click',
-            this.handleMinimizedUpdate,
-          );
-        }
-      });
     }
+
+    this.isSidebarMinimized =
+      localStorage && localStorage.getItem('isSidebarMinimized') !== null
+        ? localStorage.getItem('isSidebarMinimized') === 'true'
+        : false;
+    const sidebar = document.body;
+    if (sidebar) {
+      if (this.isSidebarMinimized) {
+        sidebar.classList.add('sidebar-minimized');
+      } else {
+        sidebar.classList.remove('sidebar-minimized');
+      }
+    }
+    this.$nextTick(() => {
+      const sidebarMinimizer = this.$el.querySelector('.sidebar-minimizer');
+      if (sidebarMinimizer) {
+        sidebarMinimizer.addEventListener('click', this.handleMinimizedUpdate);
+      }
+    });
   },
   computed: {
     name() {


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Ports https://github.com/DependencyTrack/frontend/pull/1044

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/hyades/blob/main/CONTRIBUTING.md#pull-requests)
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://dependencytrack.github.io/hyades/latest/development/documentation/) accordingly~
