### PR TITLE
Port : Fix: "Add Version" Create Button Should Be Inactive Until Version Provided

### DIFF
--- a/src/views/portfolio/projects/ProjectAddVersionModal.vue
+++ b/src/views/portfolio/projects/ProjectAddVersionModal.vue
@@ -15,7 +15,7 @@
           label-for="input-1"
           label-class="required"
         >
-        <b-form-input
+          <b-form-input
             id="input-1"
             v-model="version"
             class="required"

--- a/src/views/portfolio/projects/ProjectAddVersionModal.vue
+++ b/src/views/portfolio/projects/ProjectAddVersionModal.vue
@@ -15,7 +15,13 @@
           label-for="input-1"
           label-class="required"
         >
-          <b-form-input id="input-1" v-model="version" class="required" trim />
+        <b-form-input
+            id="input-1"
+            v-model="version"
+            class="required"
+            trim
+            required
+          />
         </b-form-group>
       </b-col>
       <b-col cols="auto">
@@ -109,9 +115,13 @@
       <b-button size="md" variant="secondary" @click="cancel()">{{
         $t('message.cancel')
       }}</b-button>
-      <b-button size="md" variant="primary" @click="createVersion()">{{
-        $t('message.create')
-      }}</b-button>
+      <b-button
+        size="md"
+        variant="primary"
+        :disabled="isSubmitButtonDisabled"
+        @click="createVersion()"
+        >{{ $t('message.create') }}</b-button
+      >
     </template>
   </b-modal>
 </template>
@@ -137,6 +147,19 @@ export default {
       includePolicyViolations: true,
       makeCloneLatest: false,
     };
+  },
+  computed: {
+    isSubmitButtonDisabled() {
+      const versionInputValue = this.version;
+      if (versionInputValue) {
+        /**
+         * * ideally we would apply the check with the input value trimmed, however, since we are already using 'trim' prop on the input value.
+         * * trimming the value here is not required.
+         */
+        return versionInputValue.length === 0;
+      }
+      return true;
+    },
   },
   methods: {
     createVersion: function () {


### PR DESCRIPTION
### Description

Fix: "Add Version" Create Button Should Be Inactive Until Version Provided.

### Addressed Issue

Ports https://github.com/DependencyTrack/frontend/pull/1052
Port change https://github.com/DependencyTrack/hyades/issues/1358

### Checklist

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/hyades/blob/main/CONTRIBUTING.md#pull-requests)
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://dependencytrack.github.io/hyades/latest/development/documentation/) accordingly
