### PR TITLE
Port : Fix caching issues upon upgrade

### DIFF
--- a/docker/etc/nginx/conf.d/default.conf
+++ b/docker/etc/nginx/conf.d/default.conf
@@ -6,6 +6,15 @@ server {
     root      /opt/owasp/dependency-track-frontend;
     index     index.html;
     try_files $uri $uri/ /index.html;
+
+    location ~ (config\.json|index\.html)$ {
+      add_header Cache-Control "max-age=0, no-cache, no-store, must-revalidate";
+      add_header Pragma "no-cache";
+      add_header Expires 0;
+    }
+
+    sub_filter '<base href=/'  '<base href=${BASE_PATH}';
+    sub_filter_once on;
   }
 
   error_page 500 502 503 504 /50x.html;


### PR DESCRIPTION
### Description

Disables caching for index.html and config.json. Assets (i.e. CSS, JS files) already have a unique value in their name for cache busting across builds.

### Addressed Issue

Ports https://github.com/DependencyTrack/frontend/pull/1051
Port change https://github.com/DependencyTrack/hyades/issues/1358

### Checklist

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/hyades/blob/main/CONTRIBUTING.md#pull-requests)
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://dependencytrack.github.io/hyades/latest/development/documentation/) accordingly
