### PR TITLE
Port : Fix affected projects tab not being updated when switching between vulnerability aliases

### DIFF
--- a/src/views/portfolio/vulnerabilities/AffectedProjects.vue
+++ b/src/views/portfolio/vulnerabilities/AffectedProjects.vue
@@ -160,6 +160,10 @@ export default {
       this.currentPage = 1;
       this.refreshTable();
     },
+    vulnId() {
+      // update url when vulnId changes, will trigger table refresh
+      this.$refs.table.refreshOptions({...this.options, url: this.apiUrl()});
+    },
   },
 };
 </script>


### PR DESCRIPTION
### Description

The affected projects tab (and table) is not updated correctly when switching between aliases.

### Addressed Issue

Ports https://github.com/DependencyTrack/frontend/pull/509
Issue: https://github.com/DependencyTrack/hyades/issues/1358

### Checklist

- [ ] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/hyades/blob/main/CONTRIBUTING.md#pull-requests)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://dependencytrack.github.io/hyades/latest/development/documentation/) accordingly
