### PR TITLE
Fix loss of permission selection for managed users when switching pages

### DIFF
--- a/src/views/administration/accessmanagement/ManagedUsers.vue
+++ b/src/views/administration/accessmanagement/ManagedUsers.vue
@@ -288,25 +288,31 @@ export default {
               },
               updatePermissionSelection: function (selections) {
                 this.$root.$emit('bv::hide::modal', 'selectPermissionModal');
+                let updatePromise = Promise.resolve();
                 for (let i = 0; i < selections.length; i++) {
                   let selection = selections[i];
                   let url = `${this.$api.BASE_URL}/${this.$api.URL_PERMISSION}/${selection.name}/user/${this.username}`;
-                  this.axios
-                    .post(url)
-                    .then((response) => {
+                  updatePromise = updatePromise.then((response) => {
+                    if (response && response.data) {
                       this.syncVariables(response.data);
-                      this.$toastr.s(this.$t('message.updated'));
-                    })
-                    .catch((error) => {
-                      if (error.response.status === 304) {
-                        //this.$toastr.w(this.$t('condition.unsuccessful_action'));
-                      } else {
-                        this.$toastr.w(
-                          this.$t('condition.unsuccessful_action'),
-                        );
-                      }
-                    });
+                    }
+                    return this.axios.post(url);
+                  });
                 }
+                updatePromise
+                  .then((response) => {
+                    if (response && response.data) {
+                      this.syncVariables(response.data);
+                    }
+                    this.$toastr.s(this.$t('message.updated'));
+                  })
+                  .catch((error) => {
+                    if (error.response.status === 304) {
+                      //this.$toastr.w(this.$t('condition.unsuccessful_action'));
+                    } else {
+                      this.$toastr.w(this.$t('condition.unsuccessful_action'));
+                    }
+                  });
               },
               removePermission: function (permission) {
                 let url = `${this.$api.BASE_URL}/${this.$api.URL_PERMISSION}/${permission.name}/user/${this.username}`;
@@ -316,7 +322,7 @@ export default {
                     this.syncVariables(response.data);
                     this.$toastr.s(this.$t('message.updated'));
                   })
-                  .catch((error) => {
+                  .catch(() => {
                     this.$toastr.w(this.$t('condition.unsuccessful_action'));
                   });
               },

--- a/src/views/administration/accessmanagement/SelectPermissionModal.vue
+++ b/src/views/administration/accessmanagement/SelectPermissionModal.vue
@@ -66,6 +66,7 @@ export default {
         queryParamsType: 'pageSize',
         pageList: '[10, 25, 50, 100]',
         pageSize: 10,
+        maintainMetaData: true,
         icons: {
           refresh: 'fa-refresh',
         },


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes loss of permission selection for managed users when switching pages.

Additionally, when multiple permissions are selected, applies them serially, rather than in parallel. This is necessary because the UI is updated based on the response to each update, which caused the UI to only show partial changes before.

There are many more places where a similar fix is needed.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Partially addresses https://github.com/DependencyTrack/hyades/issues/1651

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/hyades/blob/main/CONTRIBUTING.md#pull-requests)
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://dependencytrack.github.io/hyades/latest/development/documentation/) accordingly~
