### PR TITLE
Port : Show component properties to users with `VIEW_PORTFOLIO` permission

### DIFF
--- a/src/views/portfolio/projects/ComponentDetailsModal.vue
+++ b/src/views/portfolio/projects/ComponentDetailsModal.vue
@@ -476,7 +476,7 @@
         variant="outline-primary"
         v-b-modal.componentPropertiesModal
         v-permission:or="[
-          PERMISSIONS.PORTFOLIO_MANAGEMENT,
+          PERMISSIONS.VIEW_PORTFOLIO,
           PERMISSIONS.PORTFOLIO_MANAGEMENT_UPDATE,
         ]"
         >{{ $t('message.properties') }}</b-button

--- a/src/views/portfolio/projects/ComponentPropertiesModal.vue
+++ b/src/views/portfolio/projects/ComponentPropertiesModal.vue
@@ -20,6 +20,7 @@
         size="md"
         variant="outline-danger"
         @click="deleteProperty"
+        v-permission="PERMISSIONS.PORTFOLIO_MANAGEMENT"
         :disabled="!hasRowsSelected"
         >{{ $t('message.delete') }}</b-button
       >
@@ -29,6 +30,7 @@
       <b-button
         size="md"
         variant="primary"
+        v-permission="PERMISSIONS.PORTFOLIO_MANAGEMENT"
         v-b-modal.componentCreatePropertyModal
         >{{ $t('message.create_property') }}</b-button
       >
@@ -39,9 +41,11 @@
 <script>
 import common from '../../../shared/common';
 import xssFilters from 'xss-filters';
+import permissionsMixin from '../../../mixins/permissionsMixin';
 
 export default {
   name: 'ComponentPropertiesModal',
+  mixins: [permissionsMixin],
   props: {
     uuid: String,
   },


### PR DESCRIPTION
### Description

Shows component properties to users with `VIEW_PORTFOLIO` permission.

### Addressed Issue

Ports https://github.com/DependencyTrack/frontend/pull/1102
Issue https://github.com/DependencyTrack/hyades/issues/1358

### Checklist

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/hyades/blob/main/CONTRIBUTING.md#pull-requests)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://dependencytrack.github.io/hyades/latest/development/documentation/) accordingly
