### PR TITLE
Issue-1798 : Update pagination type for `teams`

### DIFF
--- a/src/views/administration/accessmanagement/Teams/index.vue
+++ b/src/views/administration/accessmanagement/Teams/index.vue
@@ -101,7 +101,7 @@ export default {
         showRefresh: true,
         pagination: true,
         silentSort: false,
-        sidePagination: 'client',
+        sidePagination: 'server',
         queryParamsType: 'pageSize',
         pageList: '[10, 25, 50, 100]',
         pageSize: 10,


### PR DESCRIPTION
### Description

Pagination type currently is set as client for teams. Update it to server for corresponding changes in backend.

### Addressed Issue

Issue: https://github.com/DependencyTrack/hyades/issues/1798
Backend: https://github.com/DependencyTrack/hyades-apiserver/pull/1283

### Checklist

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/hyades/blob/main/CONTRIBUTING.md#pull-requests)
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://dependencytrack.github.io/hyades/latest/development/documentation/) accordingly
