### PR TITLE
Fix multiple error toasts on login without permissions

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1289,7 +1289,6 @@ router.beforeEach((to, from, next) => {
           });
       } else {
         Vue.prototype.$toastr.e(i18n.t('condition.forbidden'));
-        next({ name: 'Dashboard', replace: true });
       }
     } else {
       // no token at all, redirect to login page


### PR DESCRIPTION
### Description

Fix multiple error toasts on login without permissions.
Multiple errors were occurring due to LOC (now ommitted) causing loop of permission check.

### Addressed Issue

Closes https://github.com/DependencyTrack/hyades/issues/1660

### Checklist

- [ ] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/hyades/blob/main/CONTRIBUTING.md#pull-requests)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://dependencytrack.github.io/hyades/latest/development/documentation/) accordingly
