### PR TITLE
feat: add OWASP analysis fields to FindingAudit component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@codemirror/lang-javascript": "6.2.4",
-        "@codemirror/lang-jinja": "^6.0.0",
+        "@codemirror/lang-jinja": "6.0.0",
         "@codemirror/lint": "6.9.4",
         "@codemirror/theme-one-dark": "6.1.3",
         "@coreui/coreui": "2.1.16",

--- a/src/views/portfolio/projects/FindingAudit.vue
+++ b/src/views/portfolio/projects/FindingAudit.vue
@@ -112,6 +112,62 @@
           trim
         />
       </b-form-group>
+      <b-form-group
+        v-if="owaspVector"
+        id="fieldset-owasp-vector"
+        label="OWASP RR Vector"
+        label-for="input-owasp-vector"
+      >
+        <b-form-input
+          id="input-owasp-vector"
+          :value="owaspVector"
+          class="form-control disabled"
+          readonly
+          trim
+        />
+      </b-form-group>
+      <b-form-group
+        v-if="owaspScore"
+        id="fieldset-owasp-score"
+        label="OWASP RR Score"
+        label-for="input-owasp-score"
+      >
+        <b-form-input
+          id="input-owasp-score"
+          :value="owaspScore"
+          class="form-control disabled"
+          readonly
+          trim
+        />
+      </b-form-group>
+      <b-form-group
+        v-if="owaspSeverity"
+        id="fieldset-owasp-severity"
+        label="OWASP RR Severity"
+        label-for="input-owasp-severity"
+      >
+        <b-form-input
+          id="input-owasp-severity"
+          :value="owaspSeverity"
+          class="form-control disabled"
+          readonly
+          trim
+        />
+      </b-form-group>
+      <b-form-group
+        v-if="analysisSource"
+        id="fieldset-analysis-source"
+        label="Analysis Source"
+        label-for="input-analysis-source"
+      >
+        <b-form-input
+          id="input-analysis-source"
+          :value="analysisSource"
+          class="form-control disabled"
+          readonly
+          trim
+        />
+      </b-form-group>
     </b-col>
     <b-col sm="6">
       <b-form-group
@@ -351,6 +407,10 @@ export default {
       analysisJustification: null,
       analysisResponse: null,
       analysisDetails: null,
+      owaspVector: null,
+      owaspScore: null,
+      owaspSeverity: null,
+      analysisSource: null,
     };
   },
   watch: {
@@ -432,6 +492,18 @@ export default {
         this.isSuppressed = analysis.isSuppressed;
       } else {
         this.isSuppressed = false;
+      }
+      if (Object.prototype.hasOwnProperty.call(analysis, 'owaspVector')) {
+        this.owaspVector = analysis.owaspVector;
+      }
+      if (Object.prototype.hasOwnProperty.call(analysis, 'owaspScore')) {
+        this.owaspScore = analysis.owaspScore;
+      }
+      if (Object.prototype.hasOwnProperty.call(analysis, 'owaspSeverity')) {
+        this.owaspSeverity = analysis.owaspSeverity;
+      }
+      if (Object.prototype.hasOwnProperty.call(analysis, 'source')) {
+        this.analysisSource = analysis.source;
       }
     },
     makeAnalysis: function () {


### PR DESCRIPTION
### Description

Add display of new analysis fields (introduced in this [PR](https://github.com/DependencyTrack/hyades-apiserver/pull/1928)) in the Finding Audit component:                                                                                                            
                                                                                                                                                                                
  - `owaspScore` - OWASP Risk Rating score                                                                                                                                        
  - `owaspSeverity` - OWASP Risk Rating severity level                                                                                                                            
  - `source` - Analysis ownership source (POLICY, VEX, MANUAL, NVD) 

Result:

<img width="1508" height="848" alt="Capture d’écran 2026-03-30 à 23 57 09" src="https://github.com/user-attachments/assets/8fdc7027-e154-42b5-a388-ec286bfb7e3d" />




<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/hyades/blob/main/CONTRIBUTING.md#pull-requests)
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://dependencytrack.github.io/hyades/latest/development/documentation/) accordingly
