### PR TITLE
Add i18n support for extension configs

### DIFF
--- a/src/views/components/JsonSchemaArrayField.vue
+++ b/src/views/components/JsonSchemaArrayField.vue
@@ -1,8 +1,8 @@
 <template>
   <div>
     <showdown
-      v-if="schema.description"
-      :markdown="schema.description"
+      v-if="localizedDescription"
+      :markdown="localizedDescription"
       class="form-text text-muted small mb-2 d-block"
     />
 
@@ -97,11 +97,19 @@ export default {
     };
   },
   computed: {
+    localizedDescription() {
+      return (
+        this.schema['x-i18n']?.[this.$i18n.locale]?.description ??
+        this.schema.description
+      );
+    },
     itemSchema() {
       return this.schema.items || { type: 'string' };
     },
     addButtonText() {
-      const itemName = this.itemSchema.title || this.$t('message.item');
+      const i18nTitle = this.itemSchema['x-i18n']?.[this.$i18n.locale]?.title;
+      const itemName =
+        i18nTitle || this.itemSchema.title || this.$t('message.item');
       return this.$t('message.add_item', { item: itemName });
     },
     isMaxItemsReached() {

--- a/src/views/components/JsonSchemaFormField.vue
+++ b/src/views/components/JsonSchemaFormField.vue
@@ -14,8 +14,8 @@
           :title="$t('admin.secret_reference_field')"
         ></i>
       </template>
-      <template v-if="!isComplexType && schema.description" v-slot:description>
-        <showdown :markdown="schema.description" />
+      <template v-if="!isComplexType && description" v-slot:description>
+        <showdown :markdown="description" />
       </template>
       <component
         :is="fieldComponent"
@@ -84,8 +84,18 @@ export default {
     fieldId() {
       return `field-${this.propertyName}`;
     },
+    localizedSchema() {
+      const i18n = this.schema['x-i18n']?.[this.$i18n.locale];
+      if (!i18n) {
+        return this.schema;
+      }
+      return { ...this.schema, ...i18n };
+    },
     label() {
-      return this.schema.title || this.propertyName;
+      return this.localizedSchema.title || this.propertyName;
+    },
+    description() {
+      return this.localizedSchema.description;
     },
     isValid() {
       return !this.validationError;
@@ -176,7 +186,7 @@ export default {
         value: this.value,
         type: this.getInputType(),
         required: this.isRequired,
-        placeholder: this.schema.examples?.[0]?.toString() || '',
+        placeholder: this.localizedSchema.examples?.[0]?.toString() || '',
         min: this.schema.minimum,
         max: this.schema.maximum,
         minlength: this.schema.minLength,


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Adds i18n support for extension configs.

Sources i18n from the extension's JSON schema. This allows i18n to be managed by extensions and keeps config schemas self-contained.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

API server PR: https://github.com/DependencyTrack/hyades-apiserver/pull/1965

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/hyades/blob/main/CONTRIBUTING.md#pull-requests)
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://dependencytrack.github.io/hyades/latest/development/documentation/) accordingly~
