### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/ci-publish.yaml
+++ b/.github/workflows/ci-publish.yaml
@@ -17,9 +17,9 @@
 name: Publish CI
 
 on:
-  release:
-    types:
-      - created
+  push:
+    tags:
+      - '[0-9]*'
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -66,13 +66,11 @@ jobs:
   release:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    permissions:
-      contents: write # Required to create commits.
     steps:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag=v6.0.2
         with:
-          token: ${{ github.repository_owner == 'DependencyTrack' && secrets.BOT_RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BOT_RELEASE_GITHUB_TOKEN }}
 
       - name: Set up NodeJs
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # tag=v6.3.0
@@ -115,7 +113,7 @@ jobs:
       - name: Create GitHub Release
         if: ${{ !inputs.dry-run }}
         env:
-          GITHUB_TOKEN: ${{ github.repository_owner == 'DependencyTrack' && secrets.BOT_RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BOT_RELEASE_GITHUB_TOKEN }}
         run: |
           VERSION=$(jq -r '.version' package.json)
           echo "Release version: ${VERSION}"


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes release workflow.

It turns out that creating a draft release doesn't trigger a release: created event. Instead, we need to push a tag, which then fires the push: tags event.

For this to work, the push must be performed with a non-default PAT. A BOT_RELEASE_GITHUB_TOKEN secrets has been created with minimal privileges, and scoped to this repository.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Effectively ports https://github.com/DependencyTrack/frontend/pull/1491

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/hyades/blob/main/CONTRIBUTING.md#pull-requests)
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://dependencytrack.github.io/hyades/latest/development/documentation/) accordingly~
