### PR TITLE
Port : Add clickable license ID in license group list

### DIFF
--- a/src/views/policy/LicenseGroupList.vue
+++ b/src/views/policy/LicenseGroupList.vue
@@ -117,30 +117,55 @@ export default {
             i18n,
             template: `
                 <div>
-                <b-row class="expanded-row">
-                  <b-col sm="6">
-                    <b-input-group-form-input id="input-license-group-name" :label="$t('message.name')" input-group-size="mb-3"
-                                              required="true" type="text" v-model="name" lazy="true" autofocus="true"
-                                              v-debounce:750ms="updateLicenseGroup" :debounce-events="'keyup'" />
-                  </b-col>
-                  <b-col sm="6">
-                  </b-col>
-                </b-row>
-                <b-row class="expanded-row">
-                  <b-col sm="12">
-                    <b-form-group :label="this.$t('message.licenses')">
-                      <div class="list-group">
-                        <span v-for="license in licenses">
-                          <actionable-list-group-item :value="license.name" v-permission:or="[PERMISSIONS.POLICY_MANAGEMENT, PERMISSIONS.POLICY_MANAGEMENT_UPDATE]" :delete-icon="true" v-on:actionClicked="removeLicense(license)"/>
-                        </span>
-                        <actionable-list-group-item v-permission:or="[PERMISSIONS.POLICY_MANAGEMENT, PERMISSIONS.POLICY_MANAGEMENT_UPDATE]" :add-icon="true" v-on:actionClicked="$root.$emit('bv::show::modal', 'selectLicenseModal')"/>
+                  <b-row class="expanded-row">
+                    <b-col sm="6">
+                      <b-input-group-form-input id="input-license-group-name" :label="$t('message.name')" input-group-size="mb-3"
+                                                required="true" type="text" v-model="name" lazy="true" autofocus="true"
+                                                v-debounce:750ms="updateLicenseGroup" :debounce-events="'keyup'" />
+                    </b-col>
+                    <b-col sm="6">
+                    </b-col>
+                  </b-row>
+                  <b-row class="expanded-row">
+                    <b-col sm="12">
+                      <b-form-group>
+                        <div>
+                          <div class="font-weight-bold mb-2">
+                            <b-row>
+                              <b-col md="8">{{$t('message.name')}}</b-col>
+                              <b-col md="3">{{$t('message.spdx_license_id')}}</b-col>
+                              <b-col md="1"></b-col>
+                            </b-row>
+                          </div>
+                          <div v-for="license in licenses" :key="license.uuid" class="mb-2">
+                            <b-row class="align-items-center">
+                              <b-col md="8" class="d-flex align-items-center">{{ license.name }}</b-col>
+                              <b-col md="3" class="d-flex align-items-center text-muted">
+                                <a
+                                  v-if="license.licenseId"
+                                  :href="'/licenses/' + encodeURIComponent(license.licenseId)"
+                                >
+                                  {{ license.licenseId }}
+                                </a>
+                                <span v-else>-</span>
+                              </b-col>
+                              <b-col md="1" class="d-flex align-items-center justify-content-end">
+                                <b-button size="sm" variant="outline-danger" @click="removeLicense(license)">
+                                  <span class="fa fa-trash"></span>
+                                </b-button>
+                              </b-col>
+                            </b-row>
+                          </div>
+                          <div>
+                            <actionable-list-group-item :add-icon="true" v-on:actionClicked="$root.$emit('bv::show::modal', 'selectLicenseModal')" />
+                          </div>
+                        </div>
+                      </b-form-group>
+                      <div style="text-align:right">
+                        <b-button variant="outline-danger" @click="deleteLicenseGroup">{{ $t('message.delete_license_group') }}</b-button>
                       </div>
-                    </b-form-group>
-                    <div style="text-align:right">
-                       <b-button v-permission:or="['POLICY_MANAGEMENT', 'POLICY_MANAGEMENT_DELETE']" variant="outline-danger" @click="deleteLicenseGroup">{{ $t('message.delete_license_group') }}</b-button>
-                    </div>
-                  </b-col>
-                </b-row>
+                    </b-col>
+                  </b-row>
                   <select-license-modal v-on:selection="updateLicenseSelection" />
                 </div>
               `,


### PR DESCRIPTION
### Description

Add clickable license ID in license group list

### Addressed Issue

https://github.com/DependencyTrack/hyades/issues/2105
Ports https://github.com/DependencyTrack/frontend/pull/1311

### Additional Details

<img width="1328" height="736" alt="Screenshot 2026-04-21 at 16 26 46" src="https://github.com/user-attachments/assets/a3844dc3-c634-4016-9a5b-9133970de3bc" />

### Checklist

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/hyades/blob/main/CONTRIBUTING.md#pull-requests)
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://dependencytrack.github.io/hyades/latest/development/documentation/) accordingly
