### PR TITLE
Account for changed list extensions API response

### DIFF
--- a/src/views/administration/AdminMenu.vue
+++ b/src/views/administration/AdminMenu.vue
@@ -86,7 +86,7 @@ export default {
         .then((response) => {
           const extensions = Array.isArray(response.data)
             ? response.data
-            : response.data.extensions || [];
+            : response.data.items || [];
           section.children = extensions.map((ext) => {
             const encodedName = encodeURIComponent(ext.name);
             const route = routePrefix + '/' + encodedName;

--- a/src/views/administration/notifications/CreateTemplateModal.vue
+++ b/src/views/administration/notifications/CreateTemplateModal.vue
@@ -135,8 +135,8 @@ export default {
       try {
         const url = `${this.$api.BASE_URL}/api/v2/extension-points/notification-publisher/extensions`;
         const response = await this.axios.get(url);
-        const extensions = Array.isArray(response?.data?.extensions)
-          ? response.data.extensions
+        const extensions = Array.isArray(response?.data?.items)
+          ? response.data.items
           : [];
         this.availableExtensions = extensions.map((extension) => ({
           value: extension.name,

--- a/src/views/administration/notifications/Publishers.vue
+++ b/src/views/administration/notifications/Publishers.vue
@@ -79,7 +79,7 @@ export default {
         const response = await this.axios.get(
           `${this.$api.BASE_URL}/api/v2/extension-points/notification-publisher/extensions`,
         );
-        this.extensions = response.data.extensions || [];
+        this.extensions = response.data.items || [];
         if (this.extensions.length > 0) {
           await this.checkPublisherConfigurability();
         }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Accounts for changed list extensions API response.

The array field is now names "items" instead of "extensions", analogue to how all other collection resources work in API v2.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

API server PR: https://github.com/DependencyTrack/hyades-apiserver/pull/2012

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/hyades/blob/main/CONTRIBUTING.md#pull-requests)
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://dependencytrack.github.io/hyades/latest/development/documentation/) accordingly~
