### PR TITLE
Allow operator and violation state to be set when creating policies

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -667,6 +667,7 @@
     "only_outdated_tooltip": "Nur Abhängigkeiten anzeigen, für die neuere stabile Versionen verfügbar sind",
     "operational_risk": "Betriebsrisiko",
     "operator": "Operator",
+    "operator_help": null,
     "osi_approved": "OSI-Zulassung",
     "outdated_only": "Nur veraltet",
     "overview": "Überblick",
@@ -912,6 +913,7 @@
     "required_component_identifier": "Eine Komponentenkennung ist erforderlich",
     "required_component_name": "Der Komponentenname ist erforderlich",
     "required_component_version": "Die Komponentenversion ist erforderlich",
+    "required_field": null,
     "required_license_id": "Die Lizenz-ID ist erforderlich",
     "required_license_name": "Der Lizenzname ist erforderlich",
     "required_project_name": "Der Projektname ist erforderlich",
@@ -1028,6 +1030,7 @@
     "vex_uploaded": "VEX hochgeladen",
     "view_details": "Details anzeigen",
     "violation_state": "Bewertung bei Verstoß",
+    "violation_state_help": null,
     "violation_type": null,
     "violations_audited": "Überprüfte Verstöße",
     "violations_unaudited": "Verstöße ungeprüft",
@@ -1058,6 +1061,8 @@
     "x_trust_boundary": "Vertrauensgrenze überschreiten"
   },
   "operator": {
+    "all": null,
+    "any": null,
     "contains_all": "enthält alle",
     "contains_any": "enthält irgendeinen",
     "is": "ist",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -667,6 +667,7 @@
     "only_outdated_tooltip": "Only show dependencies that have newer stable versions available",
     "operational_risk": "Operational Risk",
     "operator": "Operator",
+    "operator_help": "ANY = any condition matches; ALL = every condition must match",
     "osi_approved": "OSI Approved",
     "outdated_only": "Outdated only",
     "overview": "Overview",
@@ -912,6 +913,7 @@
     "required_component_identifier": "A component identifier is required",
     "required_component_name": "The component name is required",
     "required_component_version": "The component version is required",
+    "required_field": "This field is required",
     "required_license_id": "The license ID is required",
     "required_license_name": "The license name is required",
     "required_project_name": "The project name is required",
@@ -1028,6 +1030,7 @@
     "vex_uploaded": "VEX uploaded",
     "view_details": "View Details",
     "violation_state": "Violation State",
+    "violation_state_help": "Severity assigned when this policy is violated",
     "violation_type": "Violation Type",
     "violations_audited": "Violations Audited",
     "violations_unaudited": "Violations Unaudited",
@@ -1058,6 +1061,8 @@
     "x_trust_boundary": "Cross Trust Boundary"
   },
   "operator": {
+    "all": "All",
+    "any": "Any",
     "contains_all": "contains all",
     "contains_any": "contains any",
     "is": "is",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -667,6 +667,7 @@
     "only_outdated_tooltip": "Mostrar solo las dependencias que tengan versiones estables más nuevas disponibles",
     "operational_risk": "Riesgo operacional",
     "operator": "Operador",
+    "operator_help": null,
     "osi_approved": "Aprobado por OSI",
     "outdated_only": "Sólo anticuado",
     "overview": "Descripción general",
@@ -912,6 +913,7 @@
     "required_component_identifier": "Se requiere un identificador de componente",
     "required_component_name": "El nombre del componente es obligatorio.",
     "required_component_version": "La versión del componente es obligatoria.",
+    "required_field": null,
     "required_license_id": "Se requiere el ID de licencia",
     "required_license_name": "El nombre de la licencia es obligatorio.",
     "required_project_name": "El nombre del proyecto es obligatorio.",
@@ -1028,6 +1030,7 @@
     "vex_uploaded": "VEX subido",
     "view_details": "Ver detalles",
     "violation_state": "Estado de infracción",
+    "violation_state_help": null,
     "violation_type": null,
     "violations_audited": "Violaciones auditadas",
     "violations_unaudited": "Violaciones no auditadas",
@@ -1058,6 +1061,8 @@
     "x_trust_boundary": "Cruzar el límite de confianza"
   },
   "operator": {
+    "all": null,
+    "any": null,
     "contains_all": "contiene todo",
     "contains_any": "contiene cualquier",
     "is": "es",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -667,6 +667,7 @@
     "only_outdated_tooltip": "Afficher uniquement les dépendances pour lesquelles des versions stables plus récentes sont disponibles",
     "operational_risk": "Risque opérationnel",
     "operator": "Opérateur",
+    "operator_help": null,
     "osi_approved": "Approuvée par l'OSI",
     "outdated_only": "Obsolète seulement",
     "overview": "Aperçu",
@@ -912,6 +913,7 @@
     "required_component_identifier": "Un identifiant de composant est requis",
     "required_component_name": "Le nom du composant est obligatoire",
     "required_component_version": "La version du composant est requise",
+    "required_field": null,
     "required_license_id": "L'identifiant de licence est requis",
     "required_license_name": "Le nom de la licence est obligatoire",
     "required_project_name": "Le nom du projet est obligatoire",
@@ -1028,6 +1030,7 @@
     "vex_uploaded": "VEX téléversé",
     "view_details": "Voir les détails",
     "violation_state": "État de violation",
+    "violation_state_help": null,
     "violation_type": null,
     "violations_audited": "Violations auditées",
     "violations_unaudited": "Violations non auditées",
@@ -1058,6 +1061,8 @@
     "x_trust_boundary": "Limte de confiance mutuelle"
   },
   "operator": {
+    "all": null,
+    "any": null,
     "contains_all": "contient tous",
     "contains_any": "contient n'importe lequel",
     "is": "est",

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -667,6 +667,7 @@
     "only_outdated_tooltip": "केवल उन निर्भरताओं को दिखाएं जिनके नए स्थिर संस्करण उपलब्ध हैं",
     "operational_risk": "परिचालनात्मक जोखिम",
     "operator": "ऑपरेटर",
+    "operator_help": null,
     "osi_approved": "ओएसआई स्वीकृत",
     "outdated_only": "केवल पुराना",
     "overview": "अवलोकन",
@@ -912,6 +913,7 @@
     "required_component_identifier": "घटक पहचानकर्ता आवश्यक है",
     "required_component_name": "घटक का नाम आवश्यक है",
     "required_component_version": "घटक संस्करण आवश्यक है",
+    "required_field": null,
     "required_license_id": "लाइसेंस आईडी आवश्यक है",
     "required_license_name": "लाइसेंस का नाम आवश्यक है",
     "required_project_name": "प्रोजेक्ट का नाम आवश्यक है",
@@ -1028,6 +1030,7 @@
     "vex_uploaded": "VEX अपलोड किया गया",
     "view_details": "विवरण देखें",
     "violation_state": "उल्लंघन राज्य",
+    "violation_state_help": null,
     "violation_type": null,
     "violations_audited": "उल्लंघनों का लेखापरीक्षण किया गया",
     "violations_unaudited": "उल्लंघन असंपरीक्षित",
@@ -1058,6 +1061,8 @@
     "x_trust_boundary": "क्रॉस ट्रस्ट सीमा"
   },
   "operator": {
+    "all": null,
+    "any": null,
     "contains_all": "इसमें सभी शामिल हैं",
     "contains_any": "इसमें कोई भी शामिल है",
     "is": "है",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -667,6 +667,7 @@
     "only_outdated_tooltip": "Mostra solo le dipendenze per cui sono disponibili versioni stabili più recenti",
     "operational_risk": "Rischio operativo",
     "operator": "Operatore",
+    "operator_help": null,
     "osi_approved": "Approvato dall'OSI",
     "outdated_only": "Solo obsoleto",
     "overview": "Panoramica",
@@ -912,6 +913,7 @@
     "required_component_identifier": "È obbligatorio un identificatore del componente",
     "required_component_name": "Il nome del componente è obbligatorio",
     "required_component_version": "La versione del componente è obbligatoria",
+    "required_field": null,
     "required_license_id": "L'ID della licenza è obbligatorio",
     "required_license_name": "Il nome della licenza è obbligatorio",
     "required_project_name": "Il nome del progetto è obbligatorio",
@@ -1028,6 +1030,7 @@
     "vex_uploaded": "VEX caricato",
     "view_details": "Visualizza dettagli",
     "violation_state": "Stato di violazione",
+    "violation_state_help": null,
     "violation_type": null,
     "violations_audited": "Violazioni controllate",
     "violations_unaudited": "Violazioni non certificate",
@@ -1058,6 +1061,8 @@
     "x_trust_boundary": "Confine di fiducia incrociata"
   },
   "operator": {
+    "all": null,
+    "any": null,
     "contains_all": "contiene tutto",
     "contains_any": "contiene qualsiasi",
     "is": "È",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -667,6 +667,7 @@
     "only_outdated_tooltip": "新しい安定バージョンが利用可能な依存関係のみを表示する",
     "operational_risk": "運用リスク",
     "operator": "オペレーター",
+    "operator_help": null,
     "osi_approved": "OSI承認",
     "outdated_only": "古いもののみ",
     "overview": "概要",
@@ -912,6 +913,7 @@
     "required_component_identifier": "コンポーネント識別子が必要です",
     "required_component_name": "コンポーネント名は必須です",
     "required_component_version": "コンポーネントのバージョンが必要です",
+    "required_field": null,
     "required_license_id": "ライセンスIDが必要です",
     "required_license_name": "ライセンス名は必須です",
     "required_project_name": "プロジェクト名は必須です",
@@ -1028,6 +1030,7 @@
     "vex_uploaded": "VEXをアップロードしました",
     "view_details": "詳細を見る",
     "violation_state": "違反状態",
+    "violation_state_help": null,
     "violation_type": null,
     "violations_audited": "監査された違反",
     "violations_unaudited": "監査されていない違反",
@@ -1058,6 +1061,8 @@
     "x_trust_boundary": "信頼境界を越える"
   },
   "operator": {
+    "all": null,
+    "any": null,
     "contains_all": "すべてを含む",
     "contains_any": "含む",
     "is": "は",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -667,6 +667,7 @@
     "only_outdated_tooltip": "Pokazuj tylko zależności, dla których dostępne są nowsze stabilne wersje",
     "operational_risk": "Ryzyko operacyjne",
     "operator": "Operator",
+    "operator_help": null,
     "osi_approved": "Zatwierdzone przez OSI",
     "outdated_only": "Tylko nieaktualne",
     "overview": "Przegląd",
@@ -912,6 +913,7 @@
     "required_component_identifier": "Wymagany jest identyfikator komponentu",
     "required_component_name": "Nazwa komponentu jest wymagana",
     "required_component_version": "Wymagana jest wersja komponentu",
+    "required_field": null,
     "required_license_id": "Wymagany jest identyfikator licencji",
     "required_license_name": "Nazwa licencji jest wymagana",
     "required_project_name": "Nazwa projektu jest wymagana",
@@ -1028,6 +1030,7 @@
     "vex_uploaded": "Przesłano VEX",
     "view_details": "Pokaż szczegóły",
     "violation_state": "Stan naruszenia",
+    "violation_state_help": null,
     "violation_type": null,
     "violations_audited": "Naruszenia skontrolowane",
     "violations_unaudited": "Naruszenia nieskontrolowane",
@@ -1058,6 +1061,8 @@
     "x_trust_boundary": "Granica zaufania krzyżowego"
   },
   "operator": {
+    "all": null,
+    "any": null,
     "contains_all": "zawiera wszystko",
     "contains_any": "zawiera jakiekolwiek",
     "is": "Jest",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -667,6 +667,7 @@
     "only_outdated_tooltip": "Mostrar apenas dependências que tenham versões estáveis mais recentes disponíveis",
     "operational_risk": "Risco operacional",
     "operator": "Operador",
+    "operator_help": null,
     "osi_approved": "Aprovado pelo OSI",
     "outdated_only": "Apenas desatualizado",
     "overview": "Visão geral",
@@ -912,6 +913,7 @@
     "required_component_identifier": "Um identificador de componente é obrigatório",
     "required_component_name": "O nome do componente é obrigatório",
     "required_component_version": "A versão do componente é obrigatória",
+    "required_field": null,
     "required_license_id": "O ID da licença é obrigatório",
     "required_license_name": "O nome da licença é obrigatório",
     "required_project_name": "O nome do projeto é obrigatório",
@@ -1028,6 +1030,7 @@
     "vex_uploaded": "VEX carregado",
     "view_details": "Ver detalhes",
     "violation_state": "Estado de violação",
+    "violation_state_help": null,
     "violation_type": null,
     "violations_audited": "Violações auditadas",
     "violations_unaudited": "Violações não auditadas",
@@ -1058,6 +1061,8 @@
     "x_trust_boundary": "Limite de confiança cruzada"
   },
   "operator": {
+    "all": null,
+    "any": null,
     "contains_all": "contém tudo",
     "contains_any": "contém qualquer",
     "is": "é",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -667,6 +667,7 @@
     "only_outdated_tooltip": "Mostrar apenas dependências que tenham versões estáveis mais recentes disponíveis",
     "operational_risk": "Risco operacional",
     "operator": "Operador",
+    "operator_help": null,
     "osi_approved": "Aprovado pelo OSI",
     "outdated_only": "Apenas desatualizado",
     "overview": "Visão geral",
@@ -912,6 +913,7 @@
     "required_component_identifier": "Um identificador de componente é obrigatório",
     "required_component_name": "O nome do componente é obrigatório",
     "required_component_version": "A versão do componente é obrigatória",
+    "required_field": null,
     "required_license_id": "O ID da licença é obrigatório",
     "required_license_name": "O nome da licença é obrigatório",
     "required_project_name": "O nome do projeto é obrigatório",
@@ -1028,6 +1030,7 @@
     "vex_uploaded": "VEX carregado",
     "view_details": "Ver detalhes",
     "violation_state": "Estado de violação",
+    "violation_state_help": null,
     "violation_type": null,
     "violations_audited": "Violações auditadas",
     "violations_unaudited": "Violações não auditadas",
@@ -1058,6 +1061,8 @@
     "x_trust_boundary": "Limite de confiança cruzada"
   },
   "operator": {
+    "all": null,
+    "any": null,
     "contains_all": "contém tudo",
     "contains_any": "contém qualquer",
     "is": "é",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -667,6 +667,7 @@
     "only_outdated_tooltip": "Показывать только зависимости, для которых доступны более новые стабильные версии.",
     "operational_risk": "Операционный риск",
     "operator": "Оператор",
+    "operator_help": null,
     "osi_approved": "Одобрено OSI",
     "outdated_only": "Только устаревшие",
     "overview": "Обзор",
@@ -912,6 +913,7 @@
     "required_component_identifier": "Необходим идентификатор компонента",
     "required_component_name": "Необходимо указать название компонента",
     "required_component_version": "Необходима версия компонента",
+    "required_field": null,
     "required_license_id": "Необходим ID лицензии",
     "required_license_name": "Необходимо указать название лицензии",
     "required_project_name": "Необходимо указать название проекта",
@@ -1028,6 +1030,7 @@
     "vex_uploaded": "VEX загружен",
     "view_details": "Посмотреть детали",
     "violation_state": "Состояние нарушения",
+    "violation_state_help": null,
     "violation_type": null,
     "violations_audited": "Нарушения прошли аудит",
     "violations_unaudited": "Нарушения не прошли аудит",
@@ -1058,6 +1061,8 @@
     "x_trust_boundary": "Пересечение границы доверия"
   },
   "operator": {
+    "all": null,
+    "any": null,
     "contains_all": "содержит все",
     "contains_any": "содержит любой",
     "is": "является",

--- a/src/i18n/locales/uk-UA.json
+++ b/src/i18n/locales/uk-UA.json
@@ -667,6 +667,7 @@
     "only_outdated_tooltip": "Показувати лише залежності, для яких доступні новіші стабільні версії",
     "operational_risk": "Операційний ризик",
     "operator": "Оператор",
+    "operator_help": null,
     "osi_approved": "Схвалено OSI",
     "outdated_only": "Тільки застарілі",
     "overview": "Огляд",
@@ -912,6 +913,7 @@
     "required_component_identifier": "Потрібен ідентифікатор компонента",
     "required_component_name": "Потрібно вказати назву компонента",
     "required_component_version": "Потрібна версія компонента",
+    "required_field": null,
     "required_license_id": "Потрібен ідентифікатор ліцензії",
     "required_license_name": "Потрібна назва ліцензії",
     "required_project_name": "Потрібно вказати назву проекту",
@@ -1028,6 +1030,7 @@
     "vex_uploaded": "VEX завантажено",
     "view_details": "Докладніше",
     "violation_state": "Стан порушення",
+    "violation_state_help": null,
     "violation_type": null,
     "violations_audited": "Перевірені порушення",
     "violations_unaudited": "Порушення не перевірені",
@@ -1058,6 +1061,8 @@
     "x_trust_boundary": "Перетнути кордон довіри"
   },
   "operator": {
+    "all": null,
+    "any": null,
     "contains_all": "містить усе",
     "contains_any": "містить будь-які",
     "is": "є",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -667,6 +667,7 @@
     "only_outdated_tooltip": "仅显示具有较新的稳定版本的依赖项",
     "operational_risk": "操作风险",
     "operator": "操作员",
+    "operator_help": null,
     "osi_approved": "OSI 批准",
     "outdated_only": "仅限过时",
     "overview": "概述",
@@ -912,6 +913,7 @@
     "required_component_identifier": "需要组件标识符",
     "required_component_name": "组件名称为必填项",
     "required_component_version": "组件版本为必填项",
+    "required_field": null,
     "required_license_id": "需要许可证 ID",
     "required_license_name": "许可证名称为必填项",
     "required_project_name": "项目名称为必填项",
@@ -1028,6 +1030,7 @@
     "vex_uploaded": "VEX 已上传",
     "view_details": "查看详情",
     "violation_state": "违规状态",
+    "violation_state_help": null,
     "violation_type": null,
     "violations_audited": "违规行为已审计",
     "violations_unaudited": "违规行为未经审计",
@@ -1058,6 +1061,8 @@
     "x_trust_boundary": "跨越信任边界"
   },
   "operator": {
+    "all": null,
+    "any": null,
     "contains_all": "包含全部",
     "contains_any": "包含任何",
     "is": "是",

--- a/src/views/policy/CreatePolicyModal.vue
+++ b/src/views/policy/CreatePolicyModal.vue
@@ -1,67 +1,141 @@
 <template>
   <b-modal
     id="createPolicyModal"
-    @hide="resetValues()"
     size="md"
     hide-header-close
     no-stacking
     :title="$t('message.create_policy')"
+    :ok-title="$t('message.create')"
+    :cancel-title="$t('message.close')"
+    :ok-disabled="submitting"
+    :no-close-on-esc="submitting"
+    :no-close-on-backdrop="submitting"
+    @ok="onOk"
+    @show="resetValues"
+    @hidden="resetValues"
   >
-    <b-validated-input-group-form-input
-      id="identifier"
-      :label="this.$t('message.name')"
-      input-group-size="mb-3"
-      rules="required"
-      v-model="name"
-    />
+    <b-form ref="form" @submit.stop.prevent="onSubmit">
+      <b-form-group
+        :label="$t('message.name')"
+        label-class="required"
+        label-for="name-input"
+        :invalid-feedback="nameInvalidFeedback"
+        :state="nameInvalidFeedback ? false : null"
+      >
+        <b-form-input
+          id="name-input"
+          v-model="name"
+          type="text"
+          maxlength="255"
+          trim
+          autofocus
+          aria-required="true"
+          @input="nameInvalidFeedback = null"
+        />
+      </b-form-group>
 
-    <template v-slot:modal-footer="{ cancel }">
-      <b-button size="md" variant="secondary" @click="cancel()">{{
-        $t('message.close')
-      }}</b-button>
-      <b-button size="md" variant="primary" @click="createPolicy()">{{
-        $t('message.create')
-      }}</b-button>
-    </template>
+      <b-form-group
+        :label="$t('message.operator')"
+        label-class="required"
+        label-for="operator-input"
+        :description="$t('message.operator_help')"
+      >
+        <b-form-select
+          id="operator-input"
+          v-model="operator"
+          :options="operatorOptions"
+          aria-required="true"
+        />
+      </b-form-group>
+
+      <b-form-group
+        :label="$t('message.violation_state')"
+        label-class="required"
+        label-for="violation-state-input"
+        :description="$t('message.violation_state_help')"
+      >
+        <b-form-select
+          id="violation-state-input"
+          v-model="violationState"
+          :options="violationStateOptions"
+          aria-required="true"
+        />
+      </b-form-group>
+
+      <button type="submit" style="display: none" />
+    </b-form>
   </b-modal>
 </template>
 
 <script>
 import permissionsMixin from '../../mixins/permissionsMixin';
-import BValidatedInputGroupFormInput from '../../forms/BValidatedInputGroupFormInput';
 
 export default {
   name: 'createPolicyModal',
   mixins: [permissionsMixin],
-  components: {
-    BValidatedInputGroupFormInput,
-  },
   data() {
     return {
-      name: null,
+      name: '',
+      nameInvalidFeedback: null,
+      operator: 'ANY',
+      violationState: 'INFO',
+      submitting: false,
     };
   },
+  computed: {
+    operatorOptions() {
+      return [
+        { value: 'ANY', text: this.$t('operator.any') },
+        { value: 'ALL', text: this.$t('operator.all') },
+      ];
+    },
+    violationStateOptions() {
+      return [
+        { value: 'INFO', text: this.$t('violation.info') },
+        { value: 'WARN', text: this.$t('violation.warn') },
+        { value: 'FAIL', text: this.$t('violation.fail') },
+      ];
+    },
+  },
   methods: {
-    createPolicy: function () {
-      let url = `${this.$api.BASE_URL}/${this.$api.URL_POLICY}`;
+    onOk(event) {
+      event.preventDefault();
+      this.onSubmit();
+    },
+    onSubmit() {
+      if (this.submitting) return;
+      this.resetValidationFeedback();
+
+      if (!this.name || !this.name.trim()) {
+        this.nameInvalidFeedback = this.$t('message.required_field');
+        return;
+      }
+
+      this.submitting = true;
       this.axios
-        .put(url, {
+        .put(`${this.$api.BASE_URL}/${this.$api.URL_POLICY}`, {
           name: this.name,
+          operator: this.operator,
+          violationState: this.violationState,
         })
-        .then((response) => {
-          this.$root.$emit('bv::hide::modal', 'createPolicyModal');
+        .then(() => {
           this.$emit('refreshTable');
           this.$toastr.s(this.$t('message.policy_created'));
-        })
-        .catch((error) => {
-          this.$toastr.w(this.$t('condition.unsuccessful_action'));
+          this.$root.$emit('bv::hide::modal', 'createPolicyModal');
         })
         .finally(() => {
-          this.resetValues();
+          this.submitting = false;
         });
     },
-    resetValues: function () {
-      this.name = null;
+    resetValidationFeedback() {
+      this.nameInvalidFeedback = null;
+    },
+    resetValues() {
+      this.name = '';
+      this.operator = 'ANY';
+      this.violationState = 'INFO';
+      this.submitting = false;
+      this.resetValidationFeedback();
     },
   },
 };


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Allows operator and violation state to be set when creating policies.

Previously only the name could be provided

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

Noticed while writing documentation.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/hyades/blob/main/CONTRIBUTING.md#pull-requests)
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://dependencytrack.github.io/hyades/latest/development/documentation/) accordingly~
