### PR TITLE
Adjust to internal API path

### DIFF
--- a/src/views/administration/workflows/TaskQueueList.vue
+++ b/src/views/administration/workflows/TaskQueueList.vue
@@ -163,7 +163,7 @@ export default {
       return this.types[this.tabIndex];
     },
     tableDataBaseUrl() {
-      return `${this.$api.BASE_URL}/api/v2/task-queues/${this.selectedType}`;
+      return `${this.$api.BASE_URL}/api/v2/internal/task-queues/${this.selectedType}`;
     },
   },
   methods: {
@@ -174,7 +174,7 @@ export default {
     async toggleStatus(row) {
       const newStatus = row.status === 'ACTIVE' ? 'PAUSED' : 'ACTIVE';
       await this.axios.patch(
-        `${this.$api.BASE_URL}/api/v2/task-queues/${this.selectedType}/${encodeURIComponent(row.name)}`,
+        `${this.$api.BASE_URL}/api/v2/internal/task-queues/${this.selectedType}/${encodeURIComponent(row.name)}`,
         { status: newStatus },
       );
       this.$toastr.s(this.$t('message.updated'));
@@ -203,7 +203,7 @@ export default {
       }
       try {
         await this.axios.patch(
-          `${this.$api.BASE_URL}/api/v2/task-queues/${this.selectedType}/${encodeURIComponent(row.name)}`,
+          `${this.$api.BASE_URL}/api/v2/internal/task-queues/${this.selectedType}/${encodeURIComponent(row.name)}`,
           { capacity: this.editCapacityValue },
         );
         this.$toastr.s(this.$t('message.updated'));

--- a/src/views/administration/workflows/WorkflowRunDetail.vue
+++ b/src/views/administration/workflows/WorkflowRunDetail.vue
@@ -385,7 +385,7 @@ export default {
   },
   computed: {
     runUrl() {
-      return `${this.$api.BASE_URL}/api/v2/workflow-runs/${encodeURIComponent(this.id)}`;
+      return `${this.$api.BASE_URL}/api/v2/internal/workflow-runs/${encodeURIComponent(this.id)}`;
     },
     normalizedStatus() {
       if (!this.run) {

--- a/src/views/administration/workflows/WorkflowRunList.vue
+++ b/src/views/administration/workflows/WorkflowRunList.vue
@@ -233,7 +233,7 @@ export default {
       ];
     },
     tableDataBaseUrl() {
-      const url = `${this.$api.BASE_URL}/api/v2/workflow-runs`;
+      const url = `${this.$api.BASE_URL}/api/v2/internal/workflow-runs`;
       const queryParams = {};
       if (
         this.workflowNameFilter &&


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Adjusts to internal API path.

The /task-queues and /workflow-runs endpoints have been moved under the /internal path to more clearly identify them as disconnected from the v2 stability guarantee.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

API server PR: https://github.com/DependencyTrack/hyades-apiserver/pull/2062

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/hyades/blob/main/CONTRIBUTING.md#pull-requests)
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://dependencytrack.github.io/hyades/latest/development/documentation/) accordingly~
