### PR TITLE
Add `CRYPTOGRAPHIC_ASSET` classifier type

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -432,6 +432,7 @@
     "component_container": "Container",
     "component_cpe_desc": "Die CPE v2.2- oder v2.3-URI, wie von MITRE oder NIST bereitgestellt. Für alle Assets (Anwendungen, Betriebssysteme und Hardware) sollte ein CPE angegeben werden",
     "component_created": "Komponente erstellt",
+    "component_cryptographic_asset": "Kryptografisches Asset",
     "component_data": "Daten",
     "component_deleted": "Komponente gelöscht",
     "component_details": "Komponentendetails",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -432,6 +432,7 @@
     "component_container": "Container",
     "component_cpe_desc": "The CPE v2.2 or v2.3 URI as provided by MITRE or NIST. All assets (applications, operating systems, and hardware) should have a CPE specified",
     "component_created": "Component created",
+    "component_cryptographic_asset": "Cryptographic Asset",
     "component_data": "Data",
     "component_deleted": "Component deleted",
     "component_details": "Component Details",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -432,6 +432,7 @@
     "component_container": "Contenedor",
     "component_cpe_desc": "El URI de CPE v2.2 o v2.3 proporcionado por MITRE o NIST. Todos los activos (aplicaciones, sistemas operativos y hardware) deben tener un CPE especificado.",
     "component_created": "Componente creado",
+    "component_cryptographic_asset": "Activo criptográfico",
     "component_data": "Datos",
     "component_deleted": "Componente eliminado",
     "component_details": "Detalles del componente",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -432,6 +432,7 @@
     "component_container": "Conteneur",
     "component_cpe_desc": "L'URI CPE v2.2 ou v2.3 tel que fourni par MITRE ou NIST. Tous les actifs (applications, systèmes d'exploitation et matériels) doivent avoir un CPE spécifié",
     "component_created": "Composant créé",
+    "component_cryptographic_asset": "Actif cryptographique",
     "component_data": "Données",
     "component_deleted": "Composant supprimé",
     "component_details": "Détails des composants",

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -432,6 +432,7 @@
     "component_container": "कंटेनर",
     "component_cpe_desc": "MITRE या NIST द्वारा प्रदान किया गया CPE v2.2 या v2.3 URI। सभी संपत्तियों (अनुप्रयोग, ऑपरेटिंग सिस्टम और हार्डवेयर) में CPE निर्दिष्ट होना चाहिए",
     "component_created": "घटक बनाया गया",
+    "component_cryptographic_asset": "क्रिप्टोग्राफ़िक संपत्ति",
     "component_data": "डेटा",
     "component_deleted": "घटक हटा दिया गया",
     "component_details": "घटक विवरण",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -432,6 +432,7 @@
     "component_container": "Contenitore",
     "component_cpe_desc": "L'URI CPE v2.2 o v2.3 fornito da MITRE o NIST. Per tutte le risorse (applicazioni, sistemi operativi e hardware) deve essere specificato un CPE",
     "component_created": "Componente creato",
+    "component_cryptographic_asset": "Risorsa crittografica",
     "component_data": "Dati",
     "component_deleted": "Componente eliminato",
     "component_details": "Dettagli dei componenti",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -432,6 +432,7 @@
     "component_container": "コンテナ",
     "component_cpe_desc": "MITREまたはNISTによって提供されるCPE v2.2またはv2.3 URI。すべての資産（アプリケーション、オペレーティングシステム、ハードウェア）にはCPEを指定する必要があります。",
     "component_created": "コンポーネントが作成されました",
+    "component_cryptographic_asset": "暗号資産",
     "component_data": "データ",
     "component_deleted": "コンポーネントが削除されました",
     "component_details": "コンポーネントの詳細",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -432,6 +432,7 @@
     "component_container": "Kontener",
     "component_cpe_desc": "Identyfikator URI CPE v2.2 lub v2.3 dostarczony przez MITRE lub NIST. Wszystkie zasoby (aplikacje, systemy operacyjne i sprzęt) powinny mieć określony CPE",
     "component_created": "Komponent został utworzony",
+    "component_cryptographic_asset": "Zasób kryptograficzny",
     "component_data": "Dane",
     "component_deleted": "Komponent usunięty",
     "component_details": "Szczegóły komponentu",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -432,6 +432,7 @@
     "component_container": "Contêiner",
     "component_cpe_desc": "O URI do CPE v2.2 ou v2.3 conforme fornecido pelo MITRE ou NIST. Todos os ativos (aplicativos, sistemas operacionais e hardware) devem ter um CPE especificado",
     "component_created": "Componente criado",
+    "component_cryptographic_asset": "Ativo criptográfico",
     "component_data": "Dados",
     "component_deleted": "Componente excluído",
     "component_details": "Detalhes do componente",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -432,6 +432,7 @@
     "component_container": "Contêiner",
     "component_cpe_desc": "O URI do CPE v2.2 ou v2.3 conforme fornecido pelo MITRE ou NIST. Todos os ativos (aplicativos, sistemas operacionais e hardware) devem ter um CPE especificado",
     "component_created": "Componente criado",
+    "component_cryptographic_asset": "Ativo criptográfico",
     "component_data": "Dados",
     "component_deleted": "Componente excluído",
     "component_details": "Detalhes do componente",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -432,6 +432,7 @@
     "component_container": "Контейнер",
     "component_cpe_desc": "URI CPE v2.2 или v2.3, предоставленный MITRE или NIST. Все активы должны иметь указанный CPE",
     "component_created": "Компонент создан",
+    "component_cryptographic_asset": "Криптографический актив",
     "component_data": "Данные",
     "component_deleted": "Компонент удален",
     "component_details": "Детали компонента",

--- a/src/i18n/locales/uk-UA.json
+++ b/src/i18n/locales/uk-UA.json
@@ -432,6 +432,7 @@
     "component_container": "Контейнер",
     "component_cpe_desc": "URI CPE версії 2.2 або версії 2.3, наданий МІТЕР або NIST. \nУсі активи (додатки, операційні системи та апаратне забезпечення) повинні мати CPE",
     "component_created": "Компонент створено",
+    "component_cryptographic_asset": "Криптографічний актив",
     "component_data": "Дані",
     "component_deleted": "Компонент видалено",
     "component_details": "Деталі компонента",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -432,6 +432,7 @@
     "component_container": "容器",
     "component_cpe_desc": "MITRE 或 NIST 提供的 CPE v2.2 或 v2.3 URI。所有资产（应用程序、操作系统和硬件）都应指定 CPE",
     "component_created": "组件已创建",
+    "component_cryptographic_asset": "加密资产",
     "component_data": "数据",
     "component_deleted": "组件已删除",
     "component_details": "组件详细信息",

--- a/src/mixins/availableClassifiersMixin.js
+++ b/src/mixins/availableClassifiersMixin.js
@@ -32,6 +32,10 @@ export default {
           text: this.$i18n.t('message.component_machine_learning_model'),
         },
         { value: 'DATA', text: this.$i18n.t('message.component_data') },
+        {
+          value: 'CRYPTOGRAPHIC_ASSET',
+          text: this.$i18n.t('message.component_cryptographic_asset'),
+        },
       ],
     };
   },


### PR DESCRIPTION
### Description

Add `CRYPTOGRAPHIC_ASSET` option in available Classifiers.

### Addressed Issue

Backend: https://github.com/DependencyTrack/hyades-apiserver/pull/2069

### Checklist

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/hyades/blob/main/CONTRIBUTING.md#pull-requests)
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/docs) accordingly
