### PR TITLE
Port : Reset isDisabled and re-initialize teams when opening create-modal

### DIFF
--- a/src/views/portfolio/projects/ProjectCreateProjectModal.vue
+++ b/src/views/portfolio/projects/ProjectCreateProjectModal.vue
@@ -319,6 +319,9 @@ export default {
   },
   beforeMount() {
     this.$root.$on('initializeProjectCreateProjectModal', async () => {
+      this.resetValues();
+      await this.getACLEnabled();
+      await this.getAvailableTeams();
       await this.retrieveLicenses();
       this.$root.$emit('bv::show::modal', 'projectCreateProjectModal');
     });
@@ -350,6 +353,8 @@ export default {
       if (this.requiresTeam && this.availableTeams.length == 1) {
         this.project.team = this.availableTeams[0].value;
         this.isDisabled = true;
+      } else {
+        this.isDisabled = false;
       }
       this.availableTeams.sort(function (a, b) {
         return a.text.localeCompare(b.text);
@@ -451,6 +456,7 @@ export default {
         collectionLogic: null,
         team: [],
       };
+      this.isDisabled = false;
       this.tag = '';
       this.tags = [];
       this.selectedParent = null;


### PR DESCRIPTION
### Description

State of `isDisabled`, `getACLEnabled()` and `getAvailableTeams()` is recalculated everytime the modal is opened. Therefore, it cannot get 'stuck' in `isDisabled = true`. The modal shows the team selection correctly even without reloading the page.

### Addressed Issue

Ports https://github.com/DependencyTrack/frontend/pull/1410
https://github.com/DependencyTrack/hyades/issues/2105

### Checklist

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/hyades/blob/main/CONTRIBUTING.md#pull-requests)
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/docs) accordingly
