### PR TITLE
Fix broken saving of maintenance config

### DIFF
--- a/src/views/administration/configuration/Maintenance.vue
+++ b/src/views/administration/configuration/Maintenance.vue
@@ -262,41 +262,53 @@ export default {
         if (!confirmed) return;
       }
 
-      this.updateConfigProperties([
-        {
-          groupName: 'maintenance',
-          propertyName: 'metrics.retention.days',
-          propertyValue: this.metricsRetentionDays,
-        },
-        {
-          groupName: 'maintenance',
-          propertyName: 'projects.retention.type',
-          propertyValue: this.enableProjectRetention
-            ? this.projectRetentionTypeSelected
-            : null,
-        },
-        {
-          groupName: 'maintenance',
-          propertyName: 'projects.retention.days',
-          propertyValue:
-            this.projectRetentionTypeSelected === 'AGE'
-              ? this.projectRetentionDays
+      this.updateConfigProperties(
+        [
+          {
+            groupName: 'maintenance',
+            propertyName: 'metrics.retention.days',
+            propertyValue: this.metricsRetentionDays,
+          },
+          {
+            groupName: 'maintenance',
+            propertyName: 'projects.retention.type',
+            propertyValue: this.enableProjectRetention
+              ? this.projectRetentionTypeSelected
               : null,
-        },
-        {
-          groupName: 'maintenance',
-          propertyName: 'projects.retention.versions',
-          propertyValue:
-            this.projectRetentionTypeSelected === 'VERSIONS'
-              ? this.projectRetentionVersions
-              : null,
-        },
-        {
-          groupName: 'maintenance',
-          propertyName: 'tags.delete.unused',
-          propertyValue: this.tagsDeleteUnused,
-        },
-      ]).then((success) => {
+          },
+          {
+            groupName: 'maintenance',
+            propertyName: 'projects.retention.days',
+            propertyValue:
+              this.projectRetentionTypeSelected === 'AGE'
+                ? this.projectRetentionDays
+                : null,
+          },
+          {
+            groupName: 'maintenance',
+            propertyName: 'projects.retention.versions',
+            propertyValue:
+              this.projectRetentionTypeSelected === 'VERSIONS'
+                ? this.projectRetentionVersions
+                : null,
+          },
+          {
+            groupName: 'maintenance',
+            propertyName: 'tags.delete.unused',
+            propertyValue: this.tagsDeleteUnused,
+          },
+        ].filter(
+          (prop) =>
+            // NB: Integer properties can not be null.
+            // If they're not applicable per configured retention type,
+            // simply omit them instead of sending null.
+            prop.propertyValue !== null ||
+            ![
+              'projects.retention.days',
+              'projects.retention.versions',
+            ].includes(prop.propertyName),
+        ),
+      ).then((success) => {
         if (success) {
           this.initialSnapshot = JSON.stringify(this.formData);
         }


### PR DESCRIPTION

### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes broken saving of maintenance config.

When project retention type was set to "versions", the `projects.retention.days` property was being sent as `null`, which led to a rejection by the API (integer properties can't be `null`).

Instead of sending `null`, just omit the corresponding property entirely from the request.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->
N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/hyades/blob/main/CONTRIBUTING.md#pull-requests)
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/docs) accordingly~
