### PR TITLE
Use system-capabilities endpoint to determine read-only state of secret manager

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -4,6 +4,7 @@
 
 <script>
 // bootstrap-table still relies on jQuery for ajax calls, even though there's a supported Vue wrapper for it.
+import Vue from 'vue';
 import $ from 'jquery';
 import { getUrlVar } from './shared/utils';
 import { getToken, clearPermissions } from './shared/permissions';
@@ -24,14 +25,37 @@ export default {
       }
     };
 
+    const loadSystemCapabilities = () => {
+      Vue.prototype.$systemCapabilities = undefined;
+      EventBus.$emit('systemCapabilitiesUpdated', undefined);
+      this.axios
+        .get(
+          `${Vue.prototype.$api.BASE_URL}/${Vue.prototype.$api.URL_SYSTEM_CAPABILITIES}`,
+        )
+        .then((result) => {
+          Vue.prototype.$systemCapabilities = result.data.capabilities;
+          EventBus.$emit('systemCapabilitiesUpdated', result.data.capabilities);
+        })
+        .catch((error) => {
+          console.error('Failed to load system capabilities', error);
+          Vue.prototype.$systemCapabilities = undefined;
+          EventBus.$emit('systemCapabilitiesUpdated', undefined);
+        });
+    };
+
     EventBus.$on('authenticated', (token) => {
       if (token) {
         sessionStorage.setItem('token', token);
       } else {
         sessionStorage.removeItem('token');
         clearPermissions();
+        Vue.prototype.$systemCapabilities = undefined;
+        EventBus.$emit('systemCapabilitiesUpdated', undefined);
       }
       setAuthHeader(token);
+      if (token) {
+        loadSystemCapabilities();
+      }
     });
 
     // ensure $.ajaxSettings.headers exists
@@ -39,7 +63,11 @@ export default {
       headers: {},
     });
 
-    setAuthHeader(getToken());
+    const initialToken = getToken();
+    setAuthHeader(initialToken);
+    if (initialToken) {
+      loadSystemCapabilities();
+    }
 
     // Send XHR cross-site cookie credentials
     if (this.$api.WITH_CREDENTIALS) {

--- a/src/mixins/systemCapabilitiesMixin.js
+++ b/src/mixins/systemCapabilitiesMixin.js
@@ -1,0 +1,25 @@
+import EventBus from '@/shared/eventbus';
+
+export default {
+  data() {
+    return {
+      systemCapabilities: undefined,
+    };
+  },
+  created() {
+    this.systemCapabilities = this.$systemCapabilities;
+    this._onSystemCapabilitiesUpdated = (capabilities) => {
+      this.systemCapabilities = capabilities;
+    };
+    EventBus.$on(
+      'systemCapabilitiesUpdated',
+      this._onSystemCapabilitiesUpdated,
+    );
+  },
+  beforeDestroy() {
+    EventBus.$off(
+      'systemCapabilitiesUpdated',
+      this._onSystemCapabilitiesUpdated,
+    );
+  },
+};

--- a/src/shared/api.json
+++ b/src/shared/api.json
@@ -44,6 +44,7 @@
   "URL_REPOSITORY": "api/v1/repository",
   "URL_SEARCH": "api/v1/search",
   "URL_SERVICE": "api/v1/service",
+  "URL_SYSTEM_CAPABILITIES": "api/v2/internal/system-capabilities",
   "URL_TAG": "api/v1/tag",
   "URL_TEAM": "api/v1/team",
   "URL_TEAM_PERMISSION": "api/v1/permission/team",

--- a/src/views/administration/secrets/SecretsManagement.vue
+++ b/src/views/administration/secrets/SecretsManagement.vue
@@ -5,10 +5,7 @@
         <b-button
           size="md"
           variant="outline-primary"
-          v-permission:or="[
-            PERMISSIONS.SECRET_MANAGEMENT,
-            PERMISSIONS.SECRET_MANAGEMENT_CREATE,
-          ]"
+          v-if="canCreate"
           v-b-modal.createSecretModal
         >
           <span class="fa fa-plus"></span> {{ $t('message.create') }}
@@ -36,13 +33,19 @@ import common from '../../../shared/common';
 import bootstrapTableMixin from '@/mixins/bootstrapTableMixin';
 import permissionsMixin from '@/mixins/permissionsMixin';
 import routerMixin from '@/mixins/routerMixin';
+import systemCapabilitiesMixin from '@/mixins/systemCapabilitiesMixin';
 import xssFilters from 'xss-filters';
 import CreateSecretModal from '@/views/administration/secrets/CreateSecretModal.vue';
 import UpdateSecretModal from '@/views/administration/secrets/UpdateSecretModal.vue';
 import TokenPaginatedTable from '@/views/components/TokenPaginatedTable.vue';
 
 export default {
-  mixins: [bootstrapTableMixin, permissionsMixin, routerMixin],
+  mixins: [
+    bootstrapTableMixin,
+    permissionsMixin,
+    routerMixin,
+    systemCapabilitiesMixin,
+  ],
   props: {
     header: String,
   },
@@ -76,7 +79,7 @@ export default {
           title: this.$t('message.created'),
           field: 'created_at',
           formatter(value) {
-            return common.formatTimestamp(value, true);
+            return value ? common.formatTimestamp(value, true) : '-';
           },
         },
         {
@@ -139,7 +142,14 @@ export default {
   },
   computed: {
     isReadOnly() {
-      return this.$dtrack.secretManager.readOnly;
+      return this.systemCapabilities?.secret_management?.read_only !== false;
+    },
+    canCreate() {
+      return (
+        !this.isReadOnly &&
+        (this.isPermitted(this.PERMISSIONS.SECRET_MANAGEMENT) ||
+          this.isPermitted(this.PERMISSIONS.SECRET_MANAGEMENT_CREATE))
+      );
     },
     canUpdate() {
       return (


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Uses system-capabilities endpoint to determine read-only state of secret manager.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

API server PR: https://github.com/DependencyTrack/hyades-apiserver/pull/2182

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/hyades/blob/main/CONTRIBUTING.md#pull-requests)
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/docs) accordingly~
