### PR TITLE
Rework publish date and hash verification UX

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -451,6 +451,7 @@
     "component_details": "Komponentendetails",
     "component_device": "Gerät",
     "component_device_driver": "Gerätetreiber",
+    "component_download_partial": null,
     "component_file": "Datei",
     "component_filename_desc": "Gibt den beobachteten Dateinamen der Komponente an",
     "component_firmware": "Firmware",
@@ -602,6 +603,22 @@
     "group_name": "Gruppenname",
     "grouped_vulnerabilities": "Gruppierte Schwachstellen",
     "hash_type": null,
+    "hash_verification": {
+      "component_hash": null,
+      "failed_explanation": null,
+      "modal_title": null,
+      "no_common_algorithm": null,
+      "no_component_hash_explanation": null,
+      "passed_explanation": null,
+      "repository_hash": null,
+      "resolved_from": null,
+      "status": {
+        "failed": null,
+        "no_component_hash": null,
+        "passed": null,
+        "unknown": null
+      }
+    },
     "hashes": "Hashwerte",
     "hashes_short_desc": "Hash",
     "home": "Heim",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -451,6 +451,7 @@
     "component_details": "Component Details",
     "component_device": "Device",
     "component_device_driver": "Device Driver",
+    "component_download_partial": "Component list could not be fully downloaded; the file contains partial data.",
     "component_file": "File",
     "component_filename_desc": "Specifies the observed filename of the component",
     "component_firmware": "Firmware",
@@ -602,6 +603,22 @@
     "group_name": "Group Name",
     "grouped_vulnerabilities": "Grouped Vulnerabilities",
     "hash_type": "Hash Type",
+    "hash_verification": {
+      "component_hash": "Component hash",
+      "failed_explanation": "At least one hash recorded for the component does not match the corresponding hash of the artifact resolved from the repository. The component may have been tampered with, or it does not actually originate from the resolved repository.",
+      "modal_title": "Hash verification",
+      "no_common_algorithm": "The component and the repository artifact have no hash algorithms in common, so verification could not be performed.",
+      "no_component_hash_explanation": "The component has no recorded hashes, so verification could not be performed.",
+      "passed_explanation": "Every shared hash algorithm produced identical values for the component and the artifact resolved from the repository, indicating that the component matches what the repository published.",
+      "repository_hash": "Repository hash",
+      "resolved_from": "Resolved from",
+      "status": {
+        "failed": "Hash mismatch",
+        "no_component_hash": "No component hash recorded",
+        "passed": "Hashes match",
+        "unknown": "Hash verification unavailable"
+      }
+    },
     "hashes": "Hashes",
     "hashes_short_desc": "Hash",
     "home": "Home",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -451,6 +451,7 @@
     "component_details": "Detalles del componente",
     "component_device": "Dispositivo",
     "component_device_driver": "Controlador de dispositivo",
+    "component_download_partial": null,
     "component_file": "Archivo",
     "component_filename_desc": "Especifica el nombre de archivo observado del componente.",
     "component_firmware": "Firmware",
@@ -602,6 +603,22 @@
     "group_name": "Nombre del grupo",
     "grouped_vulnerabilities": "Vulnerabilidades agrupadas",
     "hash_type": null,
+    "hash_verification": {
+      "component_hash": null,
+      "failed_explanation": null,
+      "modal_title": null,
+      "no_common_algorithm": null,
+      "no_component_hash_explanation": null,
+      "passed_explanation": null,
+      "repository_hash": null,
+      "resolved_from": null,
+      "status": {
+        "failed": null,
+        "no_component_hash": null,
+        "passed": null,
+        "unknown": null
+      }
+    },
     "hashes": "hashes",
     "hashes_short_desc": "Hash",
     "home": "Hogar",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -451,6 +451,7 @@
     "component_details": "Détails des composants",
     "component_device": "Équipement",
     "component_device_driver": "Pilote de périphérique",
+    "component_download_partial": null,
     "component_file": "Fichier",
     "component_filename_desc": "Spécifie le nom de fichier observé du composant",
     "component_firmware": "Microprogramme",
@@ -602,6 +603,22 @@
     "group_name": "Nom de groupe",
     "grouped_vulnerabilities": "Vulnérabilités groupées",
     "hash_type": null,
+    "hash_verification": {
+      "component_hash": null,
+      "failed_explanation": null,
+      "modal_title": null,
+      "no_common_algorithm": null,
+      "no_component_hash_explanation": null,
+      "passed_explanation": null,
+      "repository_hash": null,
+      "resolved_from": null,
+      "status": {
+        "failed": null,
+        "no_component_hash": null,
+        "passed": null,
+        "unknown": null
+      }
+    },
     "hashes": "Condensats",
     "hashes_short_desc": "Condensat",
     "home": "Accueil",

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -451,6 +451,7 @@
     "component_details": "घटक विवरण",
     "component_device": "डिवाइस",
     "component_device_driver": "डिवाइस ड्राइवर",
+    "component_download_partial": null,
     "component_file": "फ़ाइल",
     "component_filename_desc": "घटक का प्रेक्षित फ़ाइल नाम निर्दिष्ट करता है",
     "component_firmware": "फर्मवेयर",
@@ -602,6 +603,22 @@
     "group_name": "समूह नाम",
     "grouped_vulnerabilities": "समूहीकृत कमज़ोरियाँ",
     "hash_type": null,
+    "hash_verification": {
+      "component_hash": null,
+      "failed_explanation": null,
+      "modal_title": null,
+      "no_common_algorithm": null,
+      "no_component_hash_explanation": null,
+      "passed_explanation": null,
+      "repository_hash": null,
+      "resolved_from": null,
+      "status": {
+        "failed": null,
+        "no_component_hash": null,
+        "passed": null,
+        "unknown": null
+      }
+    },
     "hashes": "हैश",
     "hashes_short_desc": "हैश",
     "home": "घर",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -451,6 +451,7 @@
     "component_details": "Dettagli dei componenti",
     "component_device": "Dispositivo",
     "component_device_driver": "Driver del dispositivo",
+    "component_download_partial": null,
     "component_file": "File",
     "component_filename_desc": "Specifica il nome file osservato del componente",
     "component_firmware": "Firmware",
@@ -602,6 +603,22 @@
     "group_name": "Nome del gruppo",
     "grouped_vulnerabilities": "Vulnerabilità raggruppate",
     "hash_type": null,
+    "hash_verification": {
+      "component_hash": null,
+      "failed_explanation": null,
+      "modal_title": null,
+      "no_common_algorithm": null,
+      "no_component_hash_explanation": null,
+      "passed_explanation": null,
+      "repository_hash": null,
+      "resolved_from": null,
+      "status": {
+        "failed": null,
+        "no_component_hash": null,
+        "passed": null,
+        "unknown": null
+      }
+    },
     "hashes": "Hash",
     "hashes_short_desc": "Hash",
     "home": "Casa",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -451,6 +451,7 @@
     "component_details": "コンポーネントの詳細",
     "component_device": "デバイス",
     "component_device_driver": "デバイスドライバー",
+    "component_download_partial": null,
     "component_file": "ファイル",
     "component_filename_desc": "コンポーネントの監視ファイル名を指定します",
     "component_firmware": "ファームウェア",
@@ -602,6 +603,22 @@
     "group_name": "グループ名",
     "grouped_vulnerabilities": "グループ化された脆弱性",
     "hash_type": null,
+    "hash_verification": {
+      "component_hash": null,
+      "failed_explanation": null,
+      "modal_title": null,
+      "no_common_algorithm": null,
+      "no_component_hash_explanation": null,
+      "passed_explanation": null,
+      "repository_hash": null,
+      "resolved_from": null,
+      "status": {
+        "failed": null,
+        "no_component_hash": null,
+        "passed": null,
+        "unknown": null
+      }
+    },
     "hashes": "ハッシュ",
     "hashes_short_desc": "ハッシュ",
     "home": "ホーム",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -451,6 +451,7 @@
     "component_details": "Szczegóły komponentu",
     "component_device": "Urządzenie",
     "component_device_driver": "Sterownik urządzenia",
+    "component_download_partial": null,
     "component_file": "Plik",
     "component_filename_desc": "Określa obserwowaną nazwę pliku komponentu",
     "component_firmware": "Oprogramowanie sprzętowe",
@@ -602,6 +603,22 @@
     "group_name": "Nazwa grupy",
     "grouped_vulnerabilities": "Zgrupowane luki w zabezpieczeniach",
     "hash_type": null,
+    "hash_verification": {
+      "component_hash": null,
+      "failed_explanation": null,
+      "modal_title": null,
+      "no_common_algorithm": null,
+      "no_component_hash_explanation": null,
+      "passed_explanation": null,
+      "repository_hash": null,
+      "resolved_from": null,
+      "status": {
+        "failed": null,
+        "no_component_hash": null,
+        "passed": null,
+        "unknown": null
+      }
+    },
     "hashes": "Hasze",
     "hashes_short_desc": "Hash",
     "home": "Dom",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -451,6 +451,7 @@
     "component_details": "Detalhes do componente",
     "component_device": "Dispositivo",
     "component_device_driver": "Driver de dispositivo",
+    "component_download_partial": null,
     "component_file": "Arquivo",
     "component_filename_desc": "Especifica o nome do arquivo observado do componente",
     "component_firmware": "Firmware",
@@ -602,6 +603,22 @@
     "group_name": "Nome do grupo",
     "grouped_vulnerabilities": "Vulnerabilidades agrupadas",
     "hash_type": null,
+    "hash_verification": {
+      "component_hash": null,
+      "failed_explanation": null,
+      "modal_title": null,
+      "no_common_algorithm": null,
+      "no_component_hash_explanation": null,
+      "passed_explanation": null,
+      "repository_hash": null,
+      "resolved_from": null,
+      "status": {
+        "failed": null,
+        "no_component_hash": null,
+        "passed": null,
+        "unknown": null
+      }
+    },
     "hashes": "Hashes",
     "hashes_short_desc": "Hash",
     "home": "Lar",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -451,6 +451,7 @@
     "component_details": "Detalhes do componente",
     "component_device": "Dispositivo",
     "component_device_driver": "Driver de dispositivo",
+    "component_download_partial": null,
     "component_file": "Arquivo",
     "component_filename_desc": "Especifica o nome do arquivo observado do componente",
     "component_firmware": "Firmware",
@@ -602,6 +603,22 @@
     "group_name": "Nome do grupo",
     "grouped_vulnerabilities": "Vulnerabilidades agrupadas",
     "hash_type": null,
+    "hash_verification": {
+      "component_hash": null,
+      "failed_explanation": null,
+      "modal_title": null,
+      "no_common_algorithm": null,
+      "no_component_hash_explanation": null,
+      "passed_explanation": null,
+      "repository_hash": null,
+      "resolved_from": null,
+      "status": {
+        "failed": null,
+        "no_component_hash": null,
+        "passed": null,
+        "unknown": null
+      }
+    },
     "hashes": "Hashes",
     "hashes_short_desc": "Hash",
     "home": "Lar",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -451,6 +451,7 @@
     "component_details": "Детали компонента",
     "component_device": "Устройство",
     "component_device_driver": "Драйвер устройства",
+    "component_download_partial": null,
     "component_file": "Файл",
     "component_filename_desc": "Указывает наблюдаемое имя файла компонента",
     "component_firmware": "Прошивка",
@@ -602,6 +603,22 @@
     "group_name": "Имя группы",
     "grouped_vulnerabilities": "Группированные уязвимости",
     "hash_type": null,
+    "hash_verification": {
+      "component_hash": null,
+      "failed_explanation": null,
+      "modal_title": null,
+      "no_common_algorithm": null,
+      "no_component_hash_explanation": null,
+      "passed_explanation": null,
+      "repository_hash": null,
+      "resolved_from": null,
+      "status": {
+        "failed": null,
+        "no_component_hash": null,
+        "passed": null,
+        "unknown": null
+      }
+    },
     "hashes": "Хэши",
     "hashes_short_desc": "Хэш",
     "home": "Главная",

--- a/src/i18n/locales/uk-UA.json
+++ b/src/i18n/locales/uk-UA.json
@@ -451,6 +451,7 @@
     "component_details": "Деталі компонента",
     "component_device": "Пристрій",
     "component_device_driver": "Драйвер пристрою",
+    "component_download_partial": null,
     "component_file": "Файл",
     "component_filename_desc": "Визначає спостережуване ім'я файлу компонента",
     "component_firmware": "Прошивка",
@@ -602,6 +603,22 @@
     "group_name": "Назва групи",
     "grouped_vulnerabilities": "Згруповані уразливості",
     "hash_type": null,
+    "hash_verification": {
+      "component_hash": null,
+      "failed_explanation": null,
+      "modal_title": null,
+      "no_common_algorithm": null,
+      "no_component_hash_explanation": null,
+      "passed_explanation": null,
+      "repository_hash": null,
+      "resolved_from": null,
+      "status": {
+        "failed": null,
+        "no_component_hash": null,
+        "passed": null,
+        "unknown": null
+      }
+    },
     "hashes": "Хеші",
     "hashes_short_desc": "Хеш",
     "home": "Головна",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -451,6 +451,7 @@
     "component_details": "元件詳細資訊",
     "component_device": "裝置",
     "component_device_driver": "裝置驅動程式",
+    "component_download_partial": null,
     "component_file": "檔案",
     "component_filename_desc": "指定觀察到的元件的檔名",
     "component_firmware": "韌體",
@@ -602,6 +603,22 @@
     "group_name": "群組名稱",
     "grouped_vulnerabilities": "分組漏洞",
     "hash_type": "哈希類型",
+    "hash_verification": {
+      "component_hash": null,
+      "failed_explanation": null,
+      "modal_title": null,
+      "no_common_algorithm": null,
+      "no_component_hash_explanation": null,
+      "passed_explanation": null,
+      "repository_hash": null,
+      "resolved_from": null,
+      "status": {
+        "failed": null,
+        "no_component_hash": null,
+        "passed": null,
+        "unknown": null
+      }
+    },
     "hashes": "雜湊",
     "hashes_short_desc": "雜湊（MD5、SHA、SHA3、Blake2b、Blake3）",
     "home": "首頁",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -451,6 +451,7 @@
     "component_details": "组件详情",
     "component_device": "设备",
     "component_device_driver": "设备驱动程序",
+    "component_download_partial": null,
     "component_file": "文件",
     "component_filename_desc": "指定观察到的组件的文件名",
     "component_firmware": "固件",
@@ -602,6 +603,22 @@
     "group_name": "组名称",
     "grouped_vulnerabilities": "分组漏洞",
     "hash_type": null,
+    "hash_verification": {
+      "component_hash": null,
+      "failed_explanation": null,
+      "modal_title": null,
+      "no_common_algorithm": null,
+      "no_component_hash_explanation": null,
+      "passed_explanation": null,
+      "repository_hash": null,
+      "resolved_from": null,
+      "status": {
+        "failed": null,
+        "no_component_hash": null,
+        "passed": null,
+        "unknown": null
+      }
+    },
     "hashes": "哈希",
     "hashes_short_desc": "哈希",
     "home": "首页",

--- a/src/mixins/filterPillsMixin.js
+++ b/src/mixins/filterPillsMixin.js
@@ -42,7 +42,7 @@ export default {
     // since initToolbar() can recreate the `.columns` div (e.g. on option changes).
     this.$nextTick(() => {
       this._adoptTableControls();
-      const table = this.$el.querySelector('table');
+      const table = this._queryEl('table');
       if (table) {
         jQuery(table).on('post-body.bs.table.filterPillsMixin', () => {
           this._adoptTableControls();
@@ -51,14 +51,23 @@ export default {
     });
   },
   beforeDestroy() {
-    const table = this.$el.querySelector('table');
+    const table = this._queryEl('table');
     if (table) {
       jQuery(table).off('post-body.bs.table.filterPillsMixin');
     }
   },
   methods: {
+    _queryEl(selector) {
+      // `$el` is a comment placeholder when the render function throws,
+      // which has no querySelector. Guard so lifecycle hooks don't pile
+      // on top of an existing render error.
+      const el = this.$el;
+      return el && typeof el.querySelector === 'function'
+        ? el.querySelector(selector)
+        : null;
+    },
     _adoptTableControls() {
-      const filterBar = this.$el.querySelector('.filter-bar');
+      const filterBar = this._queryEl('.filter-bar');
       if (!filterBar) return;
       const toolbar = filterBar.closest('.fixed-table-toolbar');
       if (!toolbar) return;

--- a/src/shared/common.js
+++ b/src/shared/common.js
@@ -613,11 +613,36 @@ $common.setQueryParams = function (url, params) {
   const isRelative = url.startsWith('/');
   const parsed = isRelative ? new URL(url, 'http://localhost') : new URL(url);
   for (const [key, value] of Object.entries(params)) {
-    parsed.searchParams.set(key, value);
+    if (Array.isArray(value)) {
+      parsed.searchParams.delete(key);
+      for (const v of value) {
+        if (v !== undefined && v !== null) {
+          parsed.searchParams.append(key, v);
+        }
+      }
+    } else if (value !== undefined && value !== null) {
+      parsed.searchParams.set(key, value);
+    }
   }
   return isRelative
     ? parsed.pathname + parsed.search + parsed.hash
     : parsed.href;
+};
+
+$common.sameQueryParams = function (a, b) {
+  const canonicalize = (params) => {
+    const pairs = [];
+    for (const [key, value] of Object.entries(params || {})) {
+      const values = Array.isArray(value) ? value : [value];
+      for (const v of values) {
+        if (v !== undefined && v !== null) {
+          pairs.push([key, String(v)]);
+        }
+      }
+    }
+    return JSON.stringify(pairs.sort());
+  };
+  return canonicalize(a) === canonicalize(b);
 };
 
 $common.getCollectionLogicText = function (i18n, project) {
@@ -696,6 +721,7 @@ export default {
   toBoolean: $common.toBoolean,
   trimToNull: $common.trimToNull,
   setQueryParams: $common.setQueryParams,
+  sameQueryParams: $common.sameQueryParams,
   OWASP_RR_LIKELIHOOD_TO_IMPACT_SEVERITY_MATRIX:
     $common.OWASP_RR_LIKELIHOOD_TO_IMPACT_SEVERITY_MATRIX,
   getCollectionLogicText: $common.getCollectionLogicText,

--- a/src/shared/hashVerificationStatus.js
+++ b/src/shared/hashVerificationStatus.js
@@ -1,0 +1,46 @@
+const STATUS_INFO = {
+  PASSED: { icon: 'fa-check-circle', color: 'status-passed' },
+  FAILED: { icon: 'fa-times-circle', color: 'status-failed' },
+  UNKNOWN: { icon: 'fa-question-circle', color: 'status-warning' },
+  NO_COMPONENT_HASH: { icon: 'fa-minus-circle', color: 'text-muted' },
+};
+
+const FALLBACK = { icon: 'fa-circle-o', color: 'text-muted' };
+
+export const HASH_ALGORITHMS = ['md5', 'sha1', 'sha256', 'sha512'];
+
+export function getHashVerificationStatusInfo(status) {
+  return STATUS_INFO[status] || FALLBACK;
+}
+
+export function normalizeHashes(hashes) {
+  const out = {};
+  if (!hashes) return out;
+  for (const algo of HASH_ALGORITHMS) {
+    const v = hashes[algo];
+    if (typeof v === 'string' && v.trim()) {
+      out[algo] = v.trim().toLowerCase();
+    }
+  }
+  return out;
+}
+
+export function computeHashVerificationStatus(
+  componentHashes,
+  repositoryHashes,
+) {
+  const repo = normalizeHashes(repositoryHashes);
+  if (Object.keys(repo).length === 0) return null;
+  const component = normalizeHashes(componentHashes);
+  if (Object.keys(component).length === 0) return 'NO_COMPONENT_HASH';
+  let common = false;
+  let anyFailed = false;
+  for (const algo of HASH_ALGORITHMS) {
+    if (algo in repo && algo in component) {
+      common = true;
+      if (repo[algo] !== component[algo]) anyFailed = true;
+    }
+  }
+  if (!common) return 'UNKNOWN';
+  return anyFailed ? 'FAILED' : 'PASSED';
+}

--- a/src/views/components/DateTimeRangeFilterPill.vue
+++ b/src/views/components/DateTimeRangeFilterPill.vue
@@ -90,6 +90,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    emitDateAsMillis: {
+      type: Boolean,
+      default: false,
+    },
     value: {
       type: Object,
       default: () => null,
@@ -104,14 +108,8 @@ export default {
   watch: {
     value: {
       immediate: true,
-      handler(val) {
-        if (val) {
-          this.tmpFrom = val.from ? this.toInputValue(val.from) : '';
-          this.tmpTo = val.to ? this.toInputValue(val.to) : '';
-        } else {
-          this.tmpFrom = '';
-          this.tmpTo = '';
-        }
+      handler() {
+        this.syncFromValue();
       },
     },
   },
@@ -123,9 +121,11 @@ export default {
       if (!this.value) return '';
 
       const from = this.value.from
-        ? this.formatDisplayValue(this.value.from)
+        ? this.formatDisplayValue(this.value.from, false)
         : '';
-      const to = this.value.to ? this.formatDisplayValue(this.value.to) : '';
+      const to = this.value.to
+        ? this.formatDisplayValue(this.value.to, true)
+        : '';
 
       if (from && to) {
         return `${from} - ${to}`;
@@ -137,12 +137,19 @@ export default {
       return '';
     },
   },
+  // `to` is stored as an exclusive upper bound: when emitDateAsMillis is on,
+  // it's the midnight *after* the selected day, so callers shift by ±1 day
+  // when converting between the user-visible date and the stored value.
   methods: {
-    formatDisplayValue(val) {
+    syncFromValue() {
+      const val = this.value;
+      this.tmpFrom = val && val.from ? this.toInputValue(val.from, false) : '';
+      this.tmpTo = val && val.to ? this.toInputValue(val.to, true) : '';
+    },
+    formatDisplayValue(val, isExclusiveUpper) {
       if (!val) return '';
       if (this.dateOnly) {
-        const [y, m, d] = val.split('-');
-        const date = new Date(y, m - 1, d);
+        const date = this.dateOnlyValueToDate(val, isExclusiveUpper);
         return date.toLocaleDateString(undefined, {
           year: 'numeric',
           month: 'short',
@@ -158,35 +165,53 @@ export default {
         minute: '2-digit',
       });
     },
-    toInputValue(val) {
+    toInputValue(val, isExclusiveUpper) {
       if (!val) return '';
       if (this.dateOnly) {
-        return val;
+        return this.formatDateInputValue(
+          this.dateOnlyValueToDate(val, isExclusiveUpper),
+        );
       }
       const date = new Date(val);
-      const year = date.getFullYear();
-      const month = String(date.getMonth() + 1).padStart(2, '0');
-      const day = String(date.getDate()).padStart(2, '0');
       const hours = String(date.getHours()).padStart(2, '0');
       const minutes = String(date.getMinutes()).padStart(2, '0');
-      return `${year}-${month}-${day}T${hours}:${minutes}`;
+      return `${this.formatDateInputValue(date)}T${hours}:${minutes}`;
     },
-    toEmitValue(inputStr) {
+    toEmitValue(inputStr, isExclusiveUpper) {
       if (!inputStr) return null;
       if (this.dateOnly) {
+        if (this.emitDateAsMillis) {
+          const [y, m, d] = inputStr.split('-').map(Number);
+          const offset = isExclusiveUpper ? 1 : 0;
+          return new Date(y, m - 1, d + offset).getTime();
+        }
         return inputStr;
       }
       return new Date(inputStr).getTime();
+    },
+    dateOnlyValueToDate(val, isExclusiveUpper) {
+      if (this.emitDateAsMillis) {
+        const date = new Date(Number(val));
+        if (isExclusiveUpper) {
+          date.setDate(date.getDate() - 1);
+        }
+        return date;
+      }
+      const [y, m, d] = String(val).split('-').map(Number);
+      return new Date(y, m - 1, d);
+    },
+    formatDateInputValue(date) {
+      const year = date.getFullYear();
+      const month = String(date.getMonth() + 1).padStart(2, '0');
+      const day = String(date.getDate()).padStart(2, '0');
+      return `${year}-${month}-${day}`;
     },
     open() {
       this.$refs.pill.open();
     },
     onDropdownHide() {
       if (this.hasFilter) {
-        this.tmpFrom = this.value.from
-          ? this.toInputValue(this.value.from)
-          : '';
-        this.tmpTo = this.value.to ? this.toInputValue(this.value.to) : '';
+        this.syncFromValue();
       } else {
         this.tmpFrom = '';
         this.tmpTo = '';
@@ -198,8 +223,8 @@ export default {
       }
 
       this.$emit('input', {
-        from: this.toEmitValue(this.tmpFrom),
-        to: this.toEmitValue(this.tmpTo),
+        from: this.toEmitValue(this.tmpFrom, false),
+        to: this.toEmitValue(this.tmpTo, true),
       });
       this.$refs.pill.hide();
     },

--- a/src/views/components/HashVerificationModal.vue
+++ b/src/views/components/HashVerificationModal.vue
@@ -1,0 +1,140 @@
+<template>
+  <b-modal :id="modalId" size="lg" hide-header-close ok-only>
+    <template v-slot:modal-title>{{
+      $t('message.hash_verification.modal_title')
+    }}</template>
+
+    <p>
+      <i
+        :class="['fa', 'mr-2', statusIcon, statusColorClass]"
+        aria-hidden="true"
+      ></i>
+      <strong>{{ statusLabel }}</strong>
+    </p>
+
+    <p v-if="explanation">{{ explanation }}</p>
+
+    <p v-if="repositoryIdentifier">
+      <strong>{{ $t('message.hash_verification.resolved_from') }}:</strong>
+      {{ repositoryIdentifier }}
+    </p>
+
+    <b-list-group v-if="rows.length > 0">
+      <b-list-group-item v-for="row in rows" :key="row.algorithm">
+        <div class="d-flex justify-content-between align-items-center mb-1">
+          <strong>{{ row.algorithm }}</strong>
+          <i
+            :class="[
+              'fa',
+              row.match === 'PASSED'
+                ? 'fa-check status-passed'
+                : 'fa-times status-failed',
+            ]"
+            aria-hidden="true"
+          ></i>
+        </div>
+        <dl class="row mb-0">
+          <dt class="col-sm-3 font-weight-normal">
+            {{ $t('message.hash_verification.component_hash') }}
+          </dt>
+          <dd class="col-sm-9 text-monospace text-break mb-1">
+            {{ row.componentHash }}
+          </dd>
+          <dt class="col-sm-3 font-weight-normal">
+            {{ $t('message.hash_verification.repository_hash') }}
+          </dt>
+          <dd class="col-sm-9 text-monospace text-break mb-0">
+            {{ row.repositoryHash }}
+          </dd>
+        </dl>
+      </b-list-group-item>
+    </b-list-group>
+  </b-modal>
+</template>
+
+<script>
+import {
+  HASH_ALGORITHMS,
+  getHashVerificationStatusInfo,
+  normalizeHashes,
+} from '@/shared/hashVerificationStatus';
+
+export default {
+  name: 'HashVerificationModal',
+  props: {
+    modalId: {
+      type: String,
+      required: true,
+    },
+    status: {
+      type: String,
+      default: null,
+    },
+    componentHashes: {
+      type: Object,
+      default: () => ({}),
+    },
+    repositoryHashes: {
+      type: Object,
+      default: () => ({}),
+    },
+    repositoryIdentifier: {
+      type: String,
+      default: null,
+    },
+  },
+  computed: {
+    statusInfo() {
+      return getHashVerificationStatusInfo(this.status);
+    },
+    statusLabel() {
+      switch (this.status) {
+        case 'PASSED':
+          return this.$t('message.hash_verification.status.passed');
+        case 'FAILED':
+          return this.$t('message.hash_verification.status.failed');
+        case 'UNKNOWN':
+          return this.$t('message.hash_verification.status.unknown');
+        case 'NO_COMPONENT_HASH':
+          return this.$t('message.hash_verification.status.no_component_hash');
+        default:
+          return '';
+      }
+    },
+    statusIcon() {
+      return this.statusInfo.icon;
+    },
+    statusColorClass() {
+      return this.statusInfo.color;
+    },
+    explanation() {
+      switch (this.status) {
+        case 'PASSED':
+          return this.$t('message.hash_verification.passed_explanation');
+        case 'FAILED':
+          return this.$t('message.hash_verification.failed_explanation');
+        case 'UNKNOWN':
+          return this.$t('message.hash_verification.no_common_algorithm');
+        case 'NO_COMPONENT_HASH':
+          return this.$t(
+            'message.hash_verification.no_component_hash_explanation',
+          );
+        default:
+          return null;
+      }
+    },
+    rows() {
+      const component = normalizeHashes(this.componentHashes);
+      const repository = normalizeHashes(this.repositoryHashes);
+      return HASH_ALGORITHMS.filter(
+        (a) => a in component && a in repository,
+      ).map((a) => ({
+        algorithm: a.toUpperCase(),
+        componentHash: component[a],
+        repositoryHash: repository[a],
+        match: component[a] === repository[a] ? 'PASSED' : 'FAILED',
+      }));
+    },
+  },
+};
+</script>

--- a/src/views/components/TokenPaginatedTable.vue
+++ b/src/views/components/TokenPaginatedTable.vue
@@ -112,10 +112,22 @@ export default {
     responseDataField: String,
     columns: Array,
     options: {},
+    // Extra query params merged into every request without becoming part of
+    // the stored page URLs. Use this for view-time concerns like `expand` so
+    // toggling them refreshes in place instead of resetting pagination.
+    // Values may be arrays — `setQueryParams` will emit repeated params.
+    extraQueryParams: {
+      type: Object,
+      default: () => ({}),
+    },
     defaultPageSize: {
       type: Number,
       default: 10,
       validator: (value) => [5, 10, 15, 20].includes(value),
+    },
+    pageSizeStorageKey: {
+      type: String,
+      default: null,
     },
     debounceMs: {
       type: Number,
@@ -123,27 +135,54 @@ export default {
     },
   },
   data() {
+    const userOptions = this.options || {};
+    const userOnColumnSwitch = userOptions.onColumnSwitch;
+    const userOnColumnSwitchAll = userOptions.onColumnSwitchAll;
+    const allowedPageSizes = [5, 10, 15, 20];
+    const storedPageSize = this.readStoredPageSize(allowedPageSizes);
     return {
       currentPageNumber: 1,
-      currentPageSize: this.defaultPageSize,
+      currentPageSize:
+        storedPageSize !== null ? storedPageSize : this.defaultPageSize,
       currentPageUrl: null,
-      allowedPageSizes: [5, 10, 15, 20],
+      allowedPageSizes,
       nextPageUrl: null,
       pageUrlHistory: [],
       tableData: [],
       tableOptions: {
         showColumns: true,
         showRefresh: true,
+        // No-op customSort: rows are server-sorted, so suppress bootstrap-table's
+        // built-in client-side reorder. onSort still fires so consumers can update
+        // their sort state and trigger a re-fetch.
+        customSort: () => {},
+        // Pass-through customSearch: search is server-side,
+        // so disable bootstrap-table's client-side filter.
+        // It crashes on dotted column fields (e.g. `a.b`) when a row lacks `a`.
+        customSearch: (data) => data,
         onRefresh: () => {
           this.refreshCurrentPage();
         },
         icons: {
           refresh: 'fa-refresh',
         },
-        ...this.options,
+        ...userOptions,
+        onColumnSwitch: (field, checked) => {
+          if (typeof userOnColumnSwitch === 'function') {
+            userOnColumnSwitch(field, checked);
+          }
+          this.emitVisibleColumns();
+        },
+        onColumnSwitchAll: (checked) => {
+          if (typeof userOnColumnSwitchAll === 'function') {
+            userOnColumnSwitchAll(checked);
+          }
+          this.emitVisibleColumns();
+        },
       },
       currentRequestId: 0,
       debounceTimer: null,
+      extraParamsTimer: null,
       totalCount: null,
       totalCountType: null,
     };
@@ -171,11 +210,12 @@ export default {
       const requestId = ++this.currentRequestId;
 
       try {
-        const urlWithLimit = common.setQueryParams(pageUrl, {
+        const fetchUrl = common.setQueryParams(pageUrl, {
+          ...this.extraQueryParams,
           limit: this.currentPageSize,
         });
 
-        const response = await this.axios.get(urlWithLimit);
+        const response = await this.axios.get(fetchUrl);
         if (requestId !== this.currentRequestId) {
           return;
         }
@@ -237,6 +277,10 @@ export default {
       }
     },
     async refreshCurrentPage() {
+      if (this.currentPageUrl === null) {
+        await this.reset();
+        return;
+      }
       await this.loadPage(this.currentPageUrl);
     },
     async goToNextPage() {
@@ -257,13 +301,32 @@ export default {
       this.totalCountType = null;
       await this.loadPage(this.baseUrl);
     },
+    emitVisibleColumns() {
+      const fields = this.$refs.table.getVisibleColumns().map((c) => c.field);
+      this.$emit('visible-columns', fields);
+    },
+    readStoredPageSize(allowedPageSizes) {
+      if (!this.pageSizeStorageKey || typeof localStorage === 'undefined') {
+        return null;
+      }
+      const raw = localStorage.getItem(this.pageSizeStorageKey);
+      if (raw === null) {
+        return null;
+      }
+      const parsed = Number(raw);
+      return allowedPageSizes.includes(parsed) ? parsed : null;
+    },
   },
   mounted() {
     this.loadPage(this.baseUrl);
+    this.emitVisibleColumns();
   },
   beforeDestroy() {
     if (this.debounceTimer) {
       clearTimeout(this.debounceTimer);
+    }
+    if (this.extraParamsTimer) {
+      clearTimeout(this.extraParamsTimer);
     }
   },
   watch: {
@@ -275,7 +338,30 @@ export default {
         this.reset();
       }, this.debounceMs);
     },
-    async currentPageSize() {
+    extraQueryParams: {
+      deep: true,
+      handler(newVal, oldVal) {
+        if (this.currentPageUrl === null) {
+          return;
+        }
+        // Skip refetch when the params are unchanged.
+        // Consumers often derive `extraQueryParams` from reactive state
+        // (e.g. visible columns) and return a fresh object each time.
+        if (common.sameQueryParams(newVal, oldVal)) {
+          return;
+        }
+        if (this.extraParamsTimer) {
+          clearTimeout(this.extraParamsTimer);
+        }
+        this.extraParamsTimer = setTimeout(() => {
+          this.refreshCurrentPage();
+        }, this.debounceMs);
+      },
+    },
+    async currentPageSize(newSize) {
+      if (this.pageSizeStorageKey && typeof localStorage !== 'undefined') {
+        localStorage.setItem(this.pageSizeStorageKey, String(newSize));
+      }
       await this.reset();
     },
   },

--- a/src/views/portfolio/components/ComponentSearch.vue
+++ b/src/views/portfolio/components/ComponentSearch.vue
@@ -76,6 +76,17 @@
           v-model="hashFilter"
           @dismiss="onFilterDismiss('hash')"
         />
+        <date-time-range-filter-pill
+          v-if="isFilterVisible('published')"
+          ref="filter_published"
+          :field-label="$t('message.published')"
+          field-name="package_artifact_published"
+          icon="fa-calendar"
+          date-only
+          emit-date-as-millis
+          v-model="publishedFilter"
+          @dismiss="onFilterDismiss('published')"
+        />
         <boolean-filter-pill
           v-if="isFilterVisible('showInactive')"
           :field-label="$t('message.show_inactive_projects')"
@@ -127,8 +138,11 @@
     <token-paginated-table
       ref="table"
       :base-url="tableDataBaseUrl"
+      :extra-query-params="extraQueryParams"
       :columns="columns"
       :options="tableOptions"
+      page-size-storage-key="ComponentSearchPageSize"
+      @visible-columns="onVisibleColumns"
     />
   </div>
 </template>
@@ -144,6 +158,37 @@ import TokenPaginatedTable from '@/views/components/TokenPaginatedTable.vue';
 import TextFilterPill from '@/views/components/TextFilterPill.vue';
 import HashFilterPill from '@/views/components/HashFilterPill.vue';
 import BooleanFilterPill from '@/views/components/BooleanFilterPill.vue';
+import DateTimeRangeFilterPill from '@/views/components/DateTimeRangeFilterPill.vue';
+
+const COLUMN_DEFAULT_VISIBILITY = {
+  name: true,
+  version: true,
+  group: true,
+  purl: true,
+  internal: false,
+  cpe: false,
+  scope: false,
+  swid_tag_id: false,
+  'project.name': true,
+  'resolved_license.license_id': false,
+  'package_artifact_metadata.published_at': false,
+  last_inherited_risk_score: false,
+  metrics: false,
+};
+
+function storedVisibility(field) {
+  if (typeof localStorage === 'undefined') return null;
+  const stored = localStorage.getItem(
+    'ComponentSearchShow' + common.capitalize(field),
+  );
+  if (stored === null) return null;
+  return stored === 'true';
+}
+
+function initialColumnVisible(field) {
+  const stored = storedVisibility(field);
+  return stored !== null ? stored : COLUMN_DEFAULT_VISIBILITY[field] === true;
+}
 
 export default {
   mixins: [permissionsMixin, filterPillsMixin],
@@ -152,6 +197,7 @@ export default {
     TextFilterPill,
     HashFilterPill,
     BooleanFilterPill,
+    DateTimeRangeFilterPill,
   },
   beforeMount() {
     const q = this.$route.query;
@@ -171,6 +217,19 @@ export default {
       };
     if (q.hash && q.hash_type)
       this.hashFilter = { hashType: q.hash_type, hash: q.hash };
+    if (
+      q.package_artifact_published_since ||
+      q.package_artifact_published_before
+    ) {
+      this.publishedFilter = {
+        from: q.package_artifact_published_since
+          ? Number(q.package_artifact_published_since)
+          : null,
+        to: q.package_artifact_published_before
+          ? Number(q.package_artifact_published_before)
+          : null,
+      };
+    }
     if (q.show_inactive === 'true') this.showInactive = true;
     if (q.project_latest_version === 'true') this.onlyLatestVersion = true;
   },
@@ -185,6 +244,7 @@ export default {
         this.cpeFilter = null;
         this.swidTagIdFilter = null;
         this.hashFilter = null;
+        this.publishedFilter = null;
         this.showInactive = false;
         this.onlyLatestVersion = false;
         this.clearPendingFilters();
@@ -214,6 +274,14 @@ export default {
         params.hash = this.hashFilter.hash;
         params.hash_type = this.hashFilter.hashType;
       }
+      if (this.publishedFilter) {
+        if (this.publishedFilter.from) {
+          params.package_artifact_published_since = this.publishedFilter.from;
+        }
+        if (this.publishedFilter.to) {
+          params.package_artifact_published_before = this.publishedFilter.to;
+        }
+      }
       if (!this.showInactive) params.project_state = 'ACTIVE';
       if (this.onlyLatestVersion) params.project_latest_version = 'true';
       return params;
@@ -223,6 +291,9 @@ export default {
       delete params.project_state;
       if (this.showInactive) params.show_inactive = 'true';
       return params;
+    },
+    onVisibleColumns(fields) {
+      this.visibleColumns = fields;
     },
     syncQueryParams() {
       const query = this.buildUrlQueryParams();
@@ -268,6 +339,11 @@ export default {
           icon: 'fa-hashtag',
         },
         {
+          name: 'published',
+          label: this.$t('message.published'),
+          icon: 'fa-calendar',
+        },
+        {
           name: 'showInactive',
           label: this.$t('message.show_inactive_projects'),
           icon: 'fa-eye',
@@ -288,9 +364,24 @@ export default {
       queryParams.sort_direction = sortDirection.toUpperCase();
       return common.setQueryParams(url, queryParams);
     },
+    extraQueryParams() {
+      const expand = new Set();
+      for (const field of this.visibleColumns) {
+        if (field === 'metrics') {
+          expand.add('metrics');
+        } else if (field === 'package_artifact_metadata.published_at') {
+          expand.add('package_artifact_metadata');
+        }
+      }
+      if (expand.size === 0) {
+        return {};
+      }
+      return { expand: [...expand] };
+    },
   },
   data() {
     return {
+      visibleColumns: [],
       groupFilter: null,
       nameFilter: null,
       versionFilter: null,
@@ -298,6 +389,7 @@ export default {
       cpeFilter: null,
       swidTagIdFilter: null,
       hashFilter: null,
+      publishedFilter: null,
       showInactive: false,
       onlyLatestVersion: false,
       booleanFilters: ['showInactive', 'onlyLatestVersion'],
@@ -322,6 +414,7 @@ export default {
           title: this.$t('message.component'),
           field: 'name',
           sortable: true,
+          visible: initialColumnVisible('name'),
           formatter(value, row) {
             let url = xssFilters.uriInUnQuotedAttr('../components/' + row.uuid);
             let dependencyGraphUrl = xssFilters.uriInUnQuotedAttr(
@@ -339,8 +432,8 @@ export default {
         {
           title: this.$t('message.version'),
           field: 'version',
-          sortable: true,
-          visible: true,
+          sortable: false,
+          visible: initialColumnVisible('version'),
           formatter(value) {
             return xssFilters.inHTMLData(common.valueWithDefault(value, ''));
           },
@@ -349,6 +442,7 @@ export default {
           title: this.$t('message.group'),
           field: 'group',
           sortable: true,
+          visible: initialColumnVisible('group'),
           formatter(value) {
             return xssFilters.inHTMLData(common.valueWithDefault(value, ''));
           },
@@ -356,7 +450,8 @@ export default {
         {
           title: this.$t('message.package_url'),
           field: 'purl',
-          sortable: true,
+          sortable: false,
+          visible: initialColumnVisible('purl'),
           formatter(value) {
             return xssFilters.inHTMLData(common.valueWithDefault(value, ''));
           },
@@ -365,7 +460,7 @@ export default {
           title: this.$t('message.internal'),
           field: 'internal',
           sortable: false,
-          visible: false,
+          visible: initialColumnVisible('internal'),
           align: 'center',
           class: 'tight',
           formatter: function (value) {
@@ -375,7 +470,8 @@ export default {
         {
           title: this.$t('message.cpe'),
           field: 'cpe',
-          sortable: true,
+          sortable: false,
+          visible: initialColumnVisible('cpe'),
           formatter(value) {
             return xssFilters.inHTMLData(common.valueWithDefault(value, ''));
           },
@@ -384,7 +480,7 @@ export default {
           title: this.$t('message.scope'),
           field: 'scope',
           sortable: false,
-          visible: false,
+          visible: initialColumnVisible('scope'),
           formatter(value) {
             return xssFilters.inHTMLData(common.valueWithDefault(value, ''));
           },
@@ -393,7 +489,7 @@ export default {
           title: this.$t('message.swid_tagid'),
           field: 'swid_tag_id',
           sortable: false,
-          visible: false,
+          visible: initialColumnVisible('swid_tag_id'),
           formatter(value) {
             return xssFilters.inHTMLData(common.valueWithDefault(value, ''));
           },
@@ -402,6 +498,7 @@ export default {
           title: this.$t('message.project_name'),
           field: 'project.name',
           sortable: false,
+          visible: initialColumnVisible('project.name'),
           formatter(_, row) {
             let url = xssFilters.uriInUnQuotedAttr(
               '../projects/' + row.project.uuid,
@@ -418,7 +515,7 @@ export default {
           title: this.$t('message.license_name'),
           field: 'resolved_license.license_id',
           sortable: false,
-          visible: false,
+          visible: initialColumnVisible('resolved_license.license_id'),
           formatter(resolved_license, row) {
             if (typeof resolved_license === 'undefined') {
               return '-';
@@ -432,17 +529,31 @@ export default {
           },
         },
         {
+          title: this.$t('message.published'),
+          field: 'package_artifact_metadata.published_at',
+          sortable: false,
+          visible: initialColumnVisible(
+            'package_artifact_metadata.published_at',
+          ),
+          formatter(value) {
+            if (value == null) {
+              return '';
+            }
+            return xssFilters.inHTMLData(common.formatTimestamp(value));
+          },
+        },
+        {
           title: this.$t('message.risk_score'),
           field: 'last_inherited_risk_score',
           sortable: true,
-          visible: false,
+          visible: initialColumnVisible('last_inherited_risk_score'),
           class: 'tight',
         },
         {
           title: this.$t('message.vulnerabilities'),
           field: 'metrics',
           sortable: false,
-          visible: false,
+          visible: initialColumnVisible('metrics'),
           formatter: function (metrics) {
             if (typeof metrics === 'undefined') {
               return '-';
@@ -461,7 +572,9 @@ export default {
               },
             });
             progressBar.$mount();
-            return progressBar.$el.outerHTML;
+            const html = progressBar.$el.outerHTML;
+            progressBar.$destroy();
+            return html;
           }.bind(this),
         },
       ],
@@ -479,6 +592,14 @@ export default {
         onSort: (name, order) => {
           this.sortBy = name;
           this.sortDirection = order;
+        },
+        onColumnSwitch: (field, checked) => {
+          if (typeof localStorage !== 'undefined') {
+            localStorage.setItem(
+              'ComponentSearchShow' + common.capitalize(field),
+              checked.toString(),
+            );
+          }
         },
       },
     };

--- a/src/views/portfolio/projects/ProjectComponents.vue
+++ b/src/views/portfolio/projects/ProjectComponents.vue
@@ -110,14 +110,16 @@
         }}</b-tooltip>
       </div>
     </div>
-    <bootstrap-table
+    <token-paginated-table
       ref="table"
+      :base-url="tableBaseUrl"
+      :extra-query-params="extraQueryParams"
       :columns="columns"
-      :data="data"
-      :options="options"
-      @on-load-success="tableLoaded"
-    >
-    </bootstrap-table>
+      :options="tableOptions"
+      page-size-storage-key="ProjectComponentsPageSize"
+      @total="onTotal"
+      @visible-columns="onVisibleColumns"
+    />
     <project-upload-bom-modal :uuid="this.uuid" />
     <project-add-component-modal
       :uuid="this.uuid"
@@ -127,13 +129,12 @@
 </template>
 
 <script>
-import {
-  compareVersions,
-  loadUserPreferencesForBootstrapTable,
-} from '@/shared/utils';
+import { compareVersions } from '@/shared/utils';
 import ComponentOccurrenceListModal from '@/views/portfolio/projects/ComponentOccurrenceListModal.vue';
+import HashVerificationModal from '@/views/components/HashVerificationModal.vue';
 import ProjectAddComponentModal from '@/views/portfolio/projects/ProjectAddComponentModal';
 import ProjectUploadBomModal from '@/views/portfolio/projects/ProjectUploadBomModal';
+import TokenPaginatedTable from '@/views/components/TokenPaginatedTable.vue';
 import { Switch as cSwitch } from '@coreui/vue';
 import $ from 'jquery';
 import Vue from 'vue';
@@ -144,31 +145,156 @@ import SeverityProgressBar from '../../components/SeverityProgressBar';
 import { get } from 'lodash-es';
 import i18n from '@/i18n';
 import bootstrapTableMixin from '@/mixins/bootstrapTableMixin';
+import {
+  computeHashVerificationStatus,
+  getHashVerificationStatusInfo,
+} from '@/shared/hashVerificationStatus';
+
+const EXPAND_BY_COLUMN = {
+  metrics: 'metrics',
+  version: 'package_metadata',
+  latest_version: 'package_metadata',
+  occurrence_count: 'occurrence_count',
+  'package_artifact_metadata.published_at': 'package_artifact_metadata',
+  'hash_verification.status': 'package_artifact_metadata',
+};
+
+const COLUMN_DEFAULT_VISIBILITY = {
+  name: true,
+  version: true,
+  'package_artifact_metadata.published_at': false,
+  latest_version: false,
+  group: true,
+  classifier: false,
+  scope: false,
+  is_internal: true,
+  'hash_verification.status': false,
+  license: true,
+  occurrence_count: false,
+  last_inherited_risk_score: true,
+  metrics: true,
+};
+
+function storedVisibility(field) {
+  if (!localStorage) return null;
+  const stored = localStorage.getItem(
+    'ProjectComponentsShow' + common.capitalize(field),
+  );
+  if (stored === null) return null;
+  return stored === 'true';
+}
+
+function initialColumnVisible(field) {
+  const stored = storedVisibility(field);
+  return stored !== null ? stored : COLUMN_DEFAULT_VISIBILITY[field] === true;
+}
+
+function readSort() {
+  const def = { name: 'name', order: 'asc' };
+  if (!localStorage) return def;
+  return {
+    name: localStorage.getItem('ProjectComponentsSortName') ?? def.name,
+    order: localStorage.getItem('ProjectComponentsSortOrder') ?? def.order,
+  };
+}
 
 export default {
   components: {
     cSwitch,
     ProjectUploadBomModal,
     ProjectAddComponentModal,
+    TokenPaginatedTable,
   },
   mixins: [bootstrapTableMixin, permissionsMixin],
-  comments: {
-    ProjectAddComponentModal,
-    ProjectUploadBomModal,
-  },
   props: {
     uuid: String,
     project: Object,
   },
   data() {
+    const initialVisibleColumns = Object.keys(COLUMN_DEFAULT_VISIBILITY).filter(
+      (f) => initialColumnVisible(f),
+    );
+    const sort = readSort();
     return {
       labelIcon: {
-        dataOn: '\u2713',
-        dataOff: '\u2715',
+        dataOn: '✓',
+        dataOff: '✕',
       },
       onlyOutdated: false,
       onlyDirect: false,
-      columns: [
+      searchText: null,
+      visibleColumns: initialVisibleColumns,
+      columns: this.buildColumns(),
+      tableOptions: {
+        toolbar: '#componentsToolbar',
+        search: true,
+        searchable: false,
+        onSearch: (text) => {
+          this.searchText = text;
+        },
+        queryParams: () => ({}),
+        onPostBody: () => {
+          this.vueFormatterInit();
+          this.initializeTooltips();
+        },
+        onColumnSwitch: (field, checked) => {
+          if (localStorage) {
+            localStorage.setItem(
+              'ProjectComponentsShow' + common.capitalize(field),
+              checked.toString(),
+            );
+          }
+        },
+        onSort: (name, order) => {
+          this.sortBy = name;
+          this.sortDirection = order;
+          if (localStorage) {
+            localStorage.setItem('ProjectComponentsSortName', name);
+            localStorage.setItem('ProjectComponentsSortOrder', order);
+          }
+        },
+        sortName: sort.name,
+        sortOrder: sort.order,
+      },
+      sortBy: sort.name,
+      sortDirection: sort.order,
+    };
+  },
+  computed: {
+    componentsUrl() {
+      return `${this.$api.BASE_URL}/api/v2/projects/${this.uuid}/components`;
+    },
+    tableBaseUrl() {
+      return common.setQueryParams(this.componentsUrl, this.buildBaseParams());
+    },
+    extraQueryParams() {
+      const expand = new Set();
+      for (const field of this.visibleColumns) {
+        if (EXPAND_BY_COLUMN[field]) {
+          expand.add(EXPAND_BY_COLUMN[field]);
+        }
+      }
+      if (expand.size === 0) {
+        return {};
+      }
+      return { expand: [...expand] };
+    },
+  },
+  methods: {
+    buildBaseParams() {
+      const params = {
+        only_outdated: this.onlyOutdated ? 'true' : 'false',
+        only_direct: this.onlyDirect ? 'true' : 'false',
+        sort_by: this.sortBy || 'name',
+        sort_direction: (this.sortDirection || 'asc').toUpperCase(),
+      };
+      if (this.searchText) {
+        params.q = this.searchText;
+      }
+      return params;
+    },
+    buildColumns() {
+      return [
         {
           field: 'state',
           checkbox: true,
@@ -178,7 +304,8 @@ export default {
           title: this.$t('message.component'),
           field: 'name',
           sortable: true,
-          formatter: (value, row, index) => {
+          visible: initialColumnVisible('name'),
+          formatter: (value, row) => {
             let url = xssFilters.uriInUnQuotedAttr(
               '../../../components/' + row.uuid,
             );
@@ -195,65 +322,70 @@ export default {
           title: this.$t('message.version'),
           field: 'version',
           sortable: true,
-          formatter: (value, row, index) => {
-            if (row.repositoryMeta && row.repositoryMeta.latestVersion) {
-              row.latestVersion = row.repositoryMeta.latestVersion;
-              if (
-                compareVersions(row.repositoryMeta.latestVersion, row.version) >
-                0
-              ) {
+          visible: initialColumnVisible('version'),
+          formatter: (value, row) => {
+            const latest =
+              row.package_metadata && row.package_metadata.latest_version
+                ? row.package_metadata.latest_version
+                : null;
+            if (latest) {
+              const cmp = compareVersions(latest, row.version);
+              if (cmp > 0) {
                 return (
                   '<span style="float:right" data-toggle="tooltip" data-placement="bottom" title="Risk: Outdated component. Current version is: ' +
-                  xssFilters.inHTMLData(row.repositoryMeta.latestVersion) +
+                  xssFilters.inHTMLData(latest) +
                   '"><i class="fa fa-exclamation-triangle status-warning" aria-hidden="true"></i></span> ' +
                   xssFilters.inHTMLData(row.version)
                 );
-              } else if (
-                compareVersions(row.repositoryMeta.latestVersion, row.version) <
-                0
-              ) {
-                // should be unstable then
+              } else if (cmp < 0) {
                 return (
                   '<span style="float:right" data-toggle="tooltip" data-placement="bottom" title="Risk: Unstable component. Current stable version is: ' +
-                  xssFilters.inHTMLData(row.repositoryMeta.latestVersion) +
+                  xssFilters.inHTMLData(latest) +
                   '"><i class="fa fa-exclamation-circle" aria-hidden="true"></i></span> ' +
                   xssFilters.inHTMLData(row.version)
                 );
-              } else {
-                return (
-                  '<span style="float:right" data-toggle="tooltip" data-placement="bottom" title="Component version is the latest available from the configured repositories"><i class="fa fa-check status-passed" aria-hidden="true"></i></span> ' +
-                  xssFilters.inHTMLData(row.version)
-                );
               }
-            } else {
-              return xssFilters.inHTMLData(common.valueWithDefault(value, ''));
+              return (
+                '<span style="float:right" data-toggle="tooltip" data-placement="bottom" title="Component version is the latest available from the configured repositories"><i class="fa fa-check status-passed" aria-hidden="true"></i></span> ' +
+                xssFilters.inHTMLData(row.version)
+              );
             }
+            return xssFilters.inHTMLData(common.valueWithDefault(value, ''));
           },
         },
         {
           title: this.$t('message.published'),
-          field: 'componentMetaInformation.publishedDate',
+          field: 'package_artifact_metadata.published_at',
           sortable: true,
-          formatter(value, row, index) {
+          visible: initialColumnVisible(
+            'package_artifact_metadata.published_at',
+          ),
+          formatter(value) {
             if (value != null) {
               return xssFilters.inHTMLData(common.formatTimestamp(value));
             }
+            return '';
           },
         },
         {
           title: this.$t('message.latest_version'),
-          field: 'latestVersion',
+          field: 'latest_version',
           sortable: false,
-          visible: false,
-          formatter(value, row, index) {
-            return xssFilters.inHTMLData(common.valueWithDefault(value, ''));
+          visible: initialColumnVisible('latest_version'),
+          formatter(_, row) {
+            const latest =
+              row.package_metadata && row.package_metadata.latest_version
+                ? row.package_metadata.latest_version
+                : '';
+            return xssFilters.inHTMLData(latest);
           },
         },
         {
           title: this.$t('message.group'),
           field: 'group',
           sortable: true,
-          formatter(value, row, index) {
+          visible: initialColumnVisible('group'),
+          formatter(value) {
             return xssFilters.inHTMLData(common.valueWithDefault(value, ''));
           },
         },
@@ -261,7 +393,7 @@ export default {
           title: this.$t('message.classifier'),
           field: 'classifier',
           sortable: true,
-          visible: false,
+          visible: initialColumnVisible('classifier'),
           formatter(value) {
             return xssFilters.inHTMLData(common.valueWithDefault(value, ''));
           },
@@ -270,146 +402,125 @@ export default {
           title: this.$t('message.scope'),
           field: 'scope',
           sortable: false,
-          visible: false,
-          formatter(value, row, index) {
+          visible: initialColumnVisible('scope'),
+          formatter(value) {
             return xssFilters.inHTMLData(common.valueWithDefault(value, ''));
           },
         },
         {
           title: this.$t('message.internal'),
-          field: 'isInternal',
+          field: 'is_internal',
           sortable: false,
+          visible: initialColumnVisible('is_internal'),
           align: 'center',
           class: 'tight',
-          formatter: function (value, row, index) {
+          formatter(value) {
             return value === true ? '<i class="fa fa-check-square-o" />' : '';
           },
         },
         {
           title: this.$t('message.integrity'),
-          field: 'componentMetaInformation.integrityMatchStatus',
-          sortable: true,
-          visible: false,
-          formatter: (value, row, index) => {
-            if (
-              Object.prototype.hasOwnProperty.call(
-                row,
-                'componentMetaInformation',
-              ) &&
-              Object.prototype.hasOwnProperty.call(
-                row.componentMetaInformation,
-                'integrityMatchStatus',
-              ) &&
-              row.componentMetaInformation.integrityMatchStatus != null
-            ) {
-              var lastFetchMessage = 'Last fetch unknown.';
-              if (
-                typeof row.componentMetaInformation.lastFetched !==
-                  'undefined' &&
-                row.componentMetaInformation.lastFetched != null
-              ) {
-                lastFetchMessage =
-                  'Last fetched on ' +
-                  common.formatTimestamp(
-                    row.componentMetaInformation.lastFetched,
-                  ) +
-                  '.';
-              }
-
-              if (
-                typeof row.componentMetaInformation.integrityRepoUrl != null
-              ) {
-                lastFetchMessage +=
-                  ' Source:  ' + row.componentMetaInformation.integrityRepoUrl;
-              }
-              if (
-                row.componentMetaInformation.integrityMatchStatus ==
-                'HASH_MATCH_PASSED'
-              ) {
-                return (
-                  '<span style="float:center" data-toggle="tooltip" data-placement="bottom" title="Component & repository hashes match. ' +
-                  xssFilters.inHTMLData(lastFetchMessage) +
-                  '"><i class="fa fa-check status-passed" aria-hidden="true"></i></span> '
-                );
-              } else if (
-                row.componentMetaInformation.integrityMatchStatus ===
-                'HASH_MATCH_FAILED'
-              ) {
-                return (
-                  '<span style="float:center" data-toggle="tooltip" data-placement="bottom" title="Component & repository hashes do not match. ' +
-                  xssFilters.inHTMLData(lastFetchMessage) +
-                  '"><i class="fa fa-exclamation-triangle status-warning" aria-hidden="true"></i></span> '
-                );
-              } else if (
-                row.componentMetaInformation.integrityMatchStatus ===
-                'COMPONENT_MISSING_HASH'
-              ) {
-                return (
-                  '<span style="float:center" data-toggle="tooltip" data-placement="bottom" title="Component hashes are missing. ' +
-                  xssFilters.inHTMLData(lastFetchMessage) +
-                  '"><i class="fa fa-exclamation-triangle status-warning" aria-hidden="true"></i></span> '
-                );
-              } else if (
-                row.componentMetaInformation.integrityMatchStatus ===
-                'HASH_MATCH_UNKNOWN'
-              ) {
-                return (
-                  '<span style="float:center" data-toggle="tooltip" data-placement="bottom" title="Repository hashes are missing. ' +
-                  xssFilters.inHTMLData(lastFetchMessage) +
-                  '"><i class="fa fa-exclamation-triangle status-warning" aria-hidden="true"></i></span> '
-                );
-              } else if (
-                row.componentMetaInformation.integrityMatchStatus ===
-                'COMPONENT_MISSING_HASH_AND_MATCH_UNKNOWN'
-              ) {
-                return (
-                  '<span style="float:center" data-toggle="tooltip" data-placement="bottom" title="Component & repository hashes are missing. ' +
-                  xssFilters.inHTMLData(lastFetchMessage) +
-                  '"><i class="fa fa-exclamation-triangle status-warning" aria-hidden="true"></i></span> '
-                );
-              }
+          field: 'hash_verification.status',
+          sortable: false,
+          visible: initialColumnVisible('hash_verification.status'),
+          formatter: (_, row, index) => {
+            const artifact = row.package_artifact_metadata;
+            const repoHashes = artifact && artifact.hashes;
+            const repoIdentifier = (artifact && artifact.resolved_from) || null;
+            const status = computeHashVerificationStatus(
+              row.hashes,
+              repoHashes,
+            );
+            if (!status) {
+              return '';
             }
+            const info = getHashVerificationStatusInfo(status);
+            const isClickable = status === 'PASSED' || status === 'FAILED';
+            const tooltipTitle = this.hashStatusLabel(status);
+            return this.vueFormatter({
+              i18n,
+              components: { HashVerificationModal },
+              template: `
+                <div>
+                  <b-link
+                    v-if="isClickable"
+                    v-b-modal="\`hashVerificationModal-${index}\`"
+                    class="hash-verification-trigger"
+                    data-toggle="tooltip"
+                    data-placement="bottom"
+                    :title="tooltipTitle"
+                  >
+                    <i :class="['fa', iconClass, colorClass]" aria-hidden="true"></i>
+                  </b-link>
+                  <span
+                    v-else
+                    data-toggle="tooltip"
+                    data-placement="bottom"
+                    :title="tooltipTitle"
+                  >
+                    <i :class="['fa', iconClass, colorClass]" aria-hidden="true"></i>
+                  </span>
+                  <hash-verification-modal
+                    v-if="isClickable"
+                    :modal-id="\`hashVerificationModal-${index}\`"
+                    :status="status"
+                    :component-hashes="componentHashes"
+                    :repository-hashes="repositoryHashes"
+                    :repository-identifier="repositoryIdentifier"
+                  />
+                </div>`,
+              data() {
+                return {
+                  status,
+                  isClickable,
+                  iconClass: info.icon,
+                  colorClass: info.color,
+                  tooltipTitle,
+                  componentHashes: row.hashes || {},
+                  repositoryHashes: repoHashes || {},
+                  repositoryIdentifier: repoIdentifier,
+                };
+              },
+            });
           },
         },
         {
           title: this.$t('message.license'),
           field: 'license',
           sortable: false,
-          formatter(value, row, index) {
-            if (Object.prototype.hasOwnProperty.call(row, 'resolvedLicense')) {
-              let licenseurl =
-                '../../../licenses/' + row.resolvedLicense.licenseId;
+          visible: initialColumnVisible('license'),
+          formatter(value, row) {
+            if (row.resolved_license) {
+              const licenseurl =
+                '../../../licenses/' + row.resolved_license.license_id;
               return (
                 '<a href="' +
                 licenseurl +
                 '">' +
-                xssFilters.inHTMLData(row.resolvedLicense.licenseId) +
+                xssFilters.inHTMLData(row.resolved_license.license_id) +
                 '</a>'
               );
             } else if (value) {
               return xssFilters.inHTMLData(common.valueWithDefault(value, ''));
-            } else if (row.licenseExpression) {
+            } else if (row.license_expression) {
               return xssFilters.inHTMLData(
-                common.valueWithDefault(row.licenseExpression, ''),
+                common.valueWithDefault(row.license_expression, ''),
               );
-            } else {
-              return '';
             }
+            return '';
           },
         },
         {
           title: this.$t('message.occurrences'),
-          field: 'occurrenceCount',
-          sortable: true,
+          field: 'occurrence_count',
+          sortable: false,
           class: 'tight',
-          visible: false,
+          visible: initialColumnVisible('occurrence_count'),
           formatter: (value, row, index) => {
             if (value) {
               return this.vueFormatter({
                 i18n,
-                components: {
-                  ComponentOccurrenceListModal,
-                },
+                components: { ComponentOccurrenceListModal },
                 template: `
                   <div>
                     <b-link v-b-modal="\`componentOccurrenceListModal-${index}\`">{{ value }}</b-link>
@@ -425,28 +536,27 @@ export default {
                 },
               });
             }
-
             return `<span style="float:right" data-toggle="tooltip" data-placement="bottom" title="${this.$t('message.occurrences_none_hint')}"><i class="fa fa-question-circle" aria-hidden="true"></i></span> ${value}`;
           },
         },
         {
           title: this.$t('message.risk_score'),
-          field: 'lastInheritedRiskScore',
+          field: 'last_inherited_risk_score',
           sortable: true,
+          visible: initialColumnVisible('last_inherited_risk_score'),
           class: 'tight',
         },
         {
           title: this.$t('message.vulnerabilities'),
           field: 'metrics',
           sortable: false,
-          formatter: function (metrics, row, index) {
-            if (typeof metrics === 'undefined') {
-              return '-'; // No vulnerability info available
+          visible: initialColumnVisible('metrics'),
+          formatter: (metrics) => {
+            if (metrics == null) {
+              return '-';
             }
-
-            // Programmatically instantiate SeverityProgressBar Vue component
-            let ComponentClass = Vue.extend(SeverityProgressBar);
-            let progressBar = new ComponentClass({
+            const ComponentClass = Vue.extend(SeverityProgressBar);
+            const progressBar = new ComponentClass({
               propsData: {
                 vulnerabilities: metrics.vulnerabilities,
                 critical: metrics.critical,
@@ -458,92 +568,66 @@ export default {
               },
             });
             progressBar.$mount();
-            return progressBar.$el.outerHTML;
-          }.bind(this),
+            const html = progressBar.$el.outerHTML;
+            progressBar.$destroy();
+            return html;
+          },
         },
-      ],
-      data: [],
-      options: {
-        onPostBody: this.initializeTooltips,
-        search: true,
-        showColumns: true,
-        showRefresh: true,
-        pagination: true,
-        silentSort: false,
-        sidePagination: 'server',
-        toolbar: '#componentsToolbar',
-        queryParamsType: 'pageSize',
-        pageList: '[10, 25, 50, 100]',
-        pageSize:
-          localStorage &&
-          localStorage.getItem('ProjectComponentsPageSize') !== null
-            ? Number(localStorage.getItem('ProjectComponentsPageSize'))
-            : 10,
-        sortName:
-          localStorage &&
-          localStorage.getItem('ProjectComponentsSortName') !== null
-            ? localStorage.getItem('ProjectComponentsSortName')
-            : undefined,
-        sortOrder:
-          localStorage &&
-          localStorage.getItem('ProjectComponentsSortOrder') !== null
-            ? localStorage.getItem('ProjectComponentsSortOrder')
-            : undefined,
-        icons: {
-          refresh: 'fa-refresh',
-        },
-        responseHandler: function (res, xhr) {
-          res.total = xhr.getResponseHeader('X-Total-Count');
-          return res;
-        },
-        url: this.apiUrl(),
-        onPageChange: (number, size) => {
-          if (localStorage) {
-            localStorage.setItem('ProjectComponentsPageSize', size.toString());
-          }
-        },
-        onColumnSwitch: (field, checked) => {
-          if (localStorage) {
-            localStorage.setItem(
-              'ProjectComponentsShow' + common.capitalize(field),
-              checked.toString(),
-            );
-          }
-        },
-        onSort: (name, order) => {
-          if (localStorage) {
-            localStorage.setItem('ProjectComponentsSortName', name);
-            localStorage.setItem('ProjectComponentsSortOrder', order);
-          }
-        },
-      },
-    };
-  },
-  methods: {
-    initializeTooltips: function () {
+      ];
+    },
+    hashStatusLabel(status) {
+      switch (status) {
+        case 'PASSED':
+          return this.$t('message.hash_verification.status.passed');
+        case 'FAILED':
+          return this.$t('message.hash_verification.status.failed');
+        case 'UNKNOWN':
+          return this.$t('message.hash_verification.status.unknown');
+        case 'NO_COMPONENT_HASH':
+          return this.$t('message.hash_verification.status.no_component_hash');
+        default:
+          return '';
+      }
+    },
+    initializeTooltips() {
       $('[data-toggle="tooltip"]').tooltip({
         trigger: 'hover',
       });
     },
-    removeDependencies: function () {
-      let selections = this.$refs.table.getSelections();
+    onVisibleColumns(fields) {
+      this.visibleColumns = fields;
+    },
+    onTotal(total) {
+      this.$emit('total', total != null ? total : '?');
+    },
+    removeDependencies() {
+      const bt = this.innerBootstrapTable();
+      if (!bt) return;
+      const selections = bt.getSelections();
       if (selections.length === 0) return;
       for (let i = 0; i < selections.length; i++) {
-        let url = `${this.$api.BASE_URL}/${this.$api.URL_COMPONENT}/${selections[i].uuid}`;
+        const url = `${this.$api.BASE_URL}/${this.$api.URL_COMPONENT}/${selections[i].uuid}`;
         this.axios
           .delete(url)
-          .then((response) => {
-            this.$refs.table.refresh({ silent: true });
+          .then(() => {
+            if (this.$refs.table) {
+              this.$refs.table.refreshCurrentPage();
+            }
             this.$toastr.s(this.$t('message.component_deleted'));
           })
-          .catch((error) => {
+          .catch(() => {
             this.$toastr.w(this.$t('condition.unsuccessful_action'));
           });
       }
-      this.$refs.table.uncheckAll();
+      bt.uncheckAll();
     },
-    downloadBom: function (data) {
-      let url = `${this.$api.BASE_URL}/${this.$api.URL_BOM}/cyclonedx/project/${this.uuid}`;
+    innerBootstrapTable() {
+      return this.$refs.table && this.$refs.table.$refs
+        ? this.$refs.table.$refs.table
+        : null;
+    },
+    downloadBom(data) {
+      const url = `${this.$api.BASE_URL}/${this.$api.URL_BOM}/cyclonedx/project/${this.uuid}`;
       this.axios
         .request({
           responseType: 'blob',
@@ -556,14 +640,16 @@ export default {
           },
         })
         .then((response) => {
-          const url = window.URL.createObjectURL(new Blob([response.data]));
+          const objectUrl = window.URL.createObjectURL(
+            new Blob([response.data]),
+          );
           const link = document.createElement('a');
-          link.href = url;
+          link.href = objectUrl;
           let filename = 'bom.json';
-          let disposition = response.headers['content-disposition'];
+          const disposition = response.headers['content-disposition'];
           if (disposition && disposition.indexOf('attachment') !== -1) {
-            let filenameRegex = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/;
-            let matches = filenameRegex.exec(disposition);
+            const filenameRegex = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/;
+            const matches = filenameRegex.exec(disposition);
             if (matches != null && matches[1]) {
               filename = matches[1].replace(/['"]/g, '');
             }
@@ -573,92 +659,87 @@ export default {
           link.click();
         });
     },
-    buildTableFile: function (json, fileType) {
-      if (fileType == 'csv') {
-        const items = json.data;
-        const header = [
-          'name',
-          'version',
-          'group',
-          'internal',
-          'resolvedLicense.licenseId',
-          'lastInheritedRiskScore',
-          'metrics.vulnerabilities',
-        ]; //Object.keys(items[0])//as long as the structure of the json doesnt change these can be static
-        const csv = [
-          header.join(','),
-          ...items.map((row) =>
-            header.map((header) => get(row, header)).join(','),
-          ),
-        ].join('\r\n');
-        const url = window.URL.createObjectURL(new Blob([csv]));
-        const link = document.createElement('a');
-        link.href = url;
-        let filename = 'componentTable.csv';
-        link.setAttribute('download', filename);
-        document.body.appendChild(link);
-        link.click();
+    buildTableFile(items, fileType) {
+      if (fileType !== 'csv') {
+        return;
       }
+      const header = [
+        'name',
+        'version',
+        'group',
+        'is_internal',
+        'resolved_license.license_id',
+        'last_inherited_risk_score',
+        'metrics.vulnerabilities',
+      ];
+      const csvEscape = (v) => {
+        if (v === null || v === undefined) return '';
+        const s = String(v);
+        return /[",\r\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+      };
+      const csv = [
+        header.join(','),
+        ...items.map((row) =>
+          header.map((h) => csvEscape(get(row, h, ''))).join(','),
+        ),
+      ].join('\r\n');
+      const url = window.URL.createObjectURL(new Blob([csv]));
+      const link = document.createElement('a');
+      link.href = url;
+      link.setAttribute('download', 'componentTable.csv');
+      document.body.appendChild(link);
+      link.click();
     },
-    downloadTable: async function (fileType) {
-      const result = await this.downloadTableJson();
-      this.buildTableFile(result, fileType);
-    },
-    downloadTableJson: async function () {
-      let url = `${this.$api.BASE_URL}/${this.$api.URL_COMPONENT}/project/${this.uuid}?limit=1000000&offset=0`;
-      try {
-        let response = await this.axios.get(url);
-        return response;
-      } catch (e) {
-        console.log(e);
-        return e;
+    async downloadTable(fileType) {
+      const result = await this.downloadAllComponents();
+      if (result.partial) {
+        this.$toastr.w(this.$t('message.component_download_partial'));
       }
+      this.buildTableFile(result.items, fileType);
     },
-    tableLoaded: function (data) {
-      loadUserPreferencesForBootstrapTable(
-        this,
-        'ProjectComponents',
-        this.$refs.table.columns,
-      );
-      if (data && Object.prototype.hasOwnProperty.call(data, 'total')) {
-        this.$emit('total', data.total);
-      } else {
-        this.$emit('total', '?');
-      }
-      this.$refs.table.hideLoading();
-      this.vueFormatterInit();
-    },
-    apiUrl: function () {
-      let url = `${this.$api.BASE_URL}/${this.$api.URL_COMPONENT}/project/${this.uuid}`;
-      if (this.onlyOutdated === undefined) {
-        url += '?onlyOutdated=false';
-      } else {
-        url += '?onlyOutdated=' + this.onlyOutdated;
-      }
-      if (this.onlyDirect === undefined) {
-        url += '&onlyDirect=false';
-      } else {
-        url += '&onlyDirect=' + this.onlyDirect;
-      }
-      return url;
-    },
-    refreshTable: function () {
-      this.$refs.table.refresh({
-        url: this.apiUrl(),
-        pageNumber: 1,
-        silent: true,
+    async downloadAllComponents() {
+      const items = [];
+      let url = common.setQueryParams(this.componentsUrl, {
+        ...this.buildBaseParams(),
+        limit: 100,
+        expand: ['metrics', 'package_metadata'],
       });
+      // Follow next_page_token until exhausted. Cap iterations to guard
+      // against runaway loops if the backend misbehaves.
+      for (let i = 0; i < 10000; i++) {
+        let response;
+        try {
+          response = await this.axios.get(url);
+        } catch (e) {
+          console.error(e);
+          return { items, partial: true };
+        }
+        const pageItems = response.data.items || [];
+        items.push(...pageItems);
+        const nextToken = response.data.next_page_token;
+        if (!nextToken) return { items, partial: false };
+        url = common.setQueryParams(url, { page_token: nextToken });
+      }
+      return { items, partial: true };
     },
-  },
-  watch: {
-    onlyOutdated() {
-      this.$refs.table.showLoading();
-      this.refreshTable();
-    },
-    onlyDirect() {
-      this.$refs.table.showLoading();
-      this.refreshTable();
+    refreshTable() {
+      if (this.$refs.table) {
+        this.$refs.table.refreshCurrentPage();
+      }
     },
   },
 };
 </script>
+
+<style>
+.hash-verification-trigger {
+  display: inline-block;
+  padding-bottom: 2px;
+  border-bottom: 1px dashed currentColor;
+  line-height: 1;
+}
+.hash-verification-trigger:hover {
+  text-decoration: none;
+  border-bottom-style: solid;
+}
+</style>


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Adapts to the API server changes that removed `componentMetaInformation` and friends from the v1 API, and moved to `package_metadata` and `package_artifact_metadata` in the v2 API.

Migrates the project components view to API v2, which includes a change to the token-paginated table.

Refactors the integrity verification UI by computing its status based on API data instead of relying on the API to return a match status. The status icons are now clickable, and open a modal that explains which hashes do not match, and from which repository they were resolved from.

Adds a date filter pill to the component search view, allowing users to filter components across all accessible projects by their publish date. This is a substitution for the lack of sortability on that column.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

API server PR: https://github.com/DependencyTrack/hyades-apiserver/pull/2200

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/hyades/blob/main/CONTRIBUTING.md#pull-requests)
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/docs) accordingly~
