### PR TITLE
Issue-2157 : Expose `direct` flag for project components

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -567,6 +567,7 @@
     "deprecated": "Veraltet",
     "description": "Beschreibung",
     "details": "Einzelheiten",
+    "direct": "Direkt",
     "direct_only": "Nur Direkt",
     "direction": "Richtung",
     "download_bom": "BOM herunterladen",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -567,6 +567,7 @@
     "deprecated": "Deprecated",
     "description": "Description",
     "details": "Details",
+    "direct": "Direct",
     "direct_only": "Direct only",
     "direction": "Direction",
     "download_bom": "Download BOM",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -567,6 +567,7 @@
     "deprecated": "Obsoleto",
     "description": "Descripción",
     "details": "Detalles",
+    "direct": "Directa",
     "direct_only": "Solo directo",
     "direction": "Dirección",
     "download_bom": "Descargar lista de materiales",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -567,6 +567,7 @@
     "deprecated": "Dépréciée",
     "description": "Description",
     "details": "Détails",
+    "direct": "Direct",
     "direct_only": "Direct uniquement",
     "direction": "Direction",
     "download_bom": "Télécharger la nomenclature",

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -567,6 +567,7 @@
     "deprecated": "पदावनत",
     "description": "विवरण",
     "details": "विवरण",
+    "direct": "प्रत्यक्ष",
     "direct_only": "केवल प्रत्यक्ष",
     "direction": "दिशा",
     "download_bom": "BOM डाउनलोड करें",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -567,6 +567,7 @@
     "deprecated": "Deprecato",
     "description": "Descrizione",
     "details": "Dettagli",
+    "direct": "Diretto",
     "direct_only": "Solo diretto",
     "direction": "Direzione",
     "download_bom": "Scarica distinta base",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -567,6 +567,7 @@
     "deprecated": "非推奨",
     "description": "説明",
     "details": "詳細",
+    "direct": "直接",
     "direct_only": "直接のみ",
     "direction": "方向",
     "download_bom": "BOMをダウンロード",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -567,6 +567,7 @@
     "deprecated": "Przestarzałe",
     "description": "Opis",
     "details": "Detale",
+    "direct": "Bezpośredni",
     "direct_only": "Tylko bezpośrednie",
     "direction": "Kierunek",
     "download_bom": "Pobierz BOM",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -567,6 +567,7 @@
     "deprecated": "Descontinuada",
     "description": "Descrição",
     "details": "Detalhes",
+    "direct": "Direta",
     "direct_only": "Somente direto",
     "direction": "Direção",
     "download_bom": "Baixe a lista técnica",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -567,6 +567,7 @@
     "deprecated": "Descontinuada",
     "description": "Descrição",
     "details": "Detalhes",
+    "direct": "Direta",
     "direct_only": "Somente direto",
     "direction": "Direção",
     "download_bom": "Baixe a lista técnica",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -567,6 +567,7 @@
     "deprecated": "Устаревший",
     "description": "Описание",
     "details": "Детали",
+    "direct": "Прямой",
     "direct_only": "Только прямые",
     "direction": "Направление",
     "download_bom": "Скачать BOM",

--- a/src/i18n/locales/uk-UA.json
+++ b/src/i18n/locales/uk-UA.json
@@ -567,6 +567,7 @@
     "deprecated": "Застарілий",
     "description": "Опис",
     "details": "Деталі",
+    "direct": "Прямий",
     "direct_only": "Тільки прямі",
     "direction": "Напрямок",
     "download_bom": "Завантажити BOM",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -567,6 +567,7 @@
     "deprecated": "已棄用",
     "description": "描述",
     "details": "詳細資訊",
+    "direct": "直接的",
     "direct_only": "僅限直接",
     "direction": "方向",
     "download_bom": "下載 BOM",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -567,6 +567,7 @@
     "deprecated": "已弃用",
     "description": "描述",
     "details": "详情",
+    "direct": "直接的",
     "direct_only": "仅直接依赖",
     "direction": "方向",
     "download_bom": "下载 BOM",

--- a/src/views/portfolio/projects/ProjectComponents.vue
+++ b/src/views/portfolio/projects/ProjectComponents.vue
@@ -167,7 +167,8 @@ const COLUMN_DEFAULT_VISIBILITY = {
   group: true,
   classifier: false,
   scope: false,
-  is_internal: true,
+  internal: true,
+  direct: true,
   'hash_verification.status': false,
   license: true,
   occurrence_count: false,
@@ -409,9 +410,20 @@ export default {
         },
         {
           title: this.$t('message.internal'),
-          field: 'is_internal',
+          field: 'internal',
           sortable: false,
-          visible: initialColumnVisible('is_internal'),
+          visible: initialColumnVisible('internal'),
+          align: 'center',
+          class: 'tight',
+          formatter(value) {
+            return value === true ? '<i class="fa fa-check-square-o" />' : '';
+          },
+        },
+        {
+          title: this.$t('message.direct'),
+          field: 'direct',
+          sortable: false,
+          visible: initialColumnVisible('direct'),
           align: 'center',
           class: 'tight',
           formatter(value) {
@@ -667,7 +679,8 @@ export default {
         'name',
         'version',
         'group',
-        'is_internal',
+        'internal',
+        'direct',
         'resolved_license.license_id',
         'last_inherited_risk_score',
         'metrics.vulnerabilities',


### PR DESCRIPTION
### Description

Expose `direct` flag for project components in UI.
Fix `internal` flag mapping.

### Addressed Issue

https://github.com/DependencyTrack/dependency-track/issues/6183
Backend: https://github.com/DependencyTrack/hyades-apiserver/pull/2168

### Additional Details

<img width="1334" height="724" alt="Screenshot 2026-05-29 at 12 03 51" src="https://github.com/user-attachments/assets/edee22e8-978d-4033-adcf-32ed7865ba28" />

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/hyades/blob/main/CONTRIBUTING.md#pull-requests)
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/docs) accordingly
